### PR TITLE
Refactor: Replace binary file copying with shutil in createbatch

### DIFF
--- a/createbatch/shared/file_operations.py
+++ b/createbatch/shared/file_operations.py
@@ -4,18 +4,30 @@ import csv
 from typing import List, Dict
 from tqdm import tqdm
 import os
+import shutil
 
 def copy_file(src: str, dest: str, overwrite: bool = True) -> None:
     """
-    Copy a file from src to dest. Overwrite if specified.
+    Copy a file from src to dest using shutil.copy2 for proper metadata preservation.
+    
+    Args:
+        src: Source file path
+        dest: Destination file path
+        overwrite: Whether to overwrite existing files
     """
     logging.debug("Copying file from %s to %s (overwrite=%s)", src, dest, overwrite)
     if not overwrite and os.path.exists(dest):
         logging.debug("File exists and overwrite disabled, skipping: %s", dest)
         return
+    
     try:
-        with open(src, 'rb') as fsrc, open(dest, 'wb') as fdest:
-            fdest.write(fsrc.read())
+        # Ensure destination directory exists
+        dest_dir = os.path.dirname(dest)
+        if dest_dir:
+            ensure_directory(dest_dir)
+        
+        # Copy file with metadata preservation
+        shutil.copy2(src, dest)
         logging.debug("Copied file from %s to %s", src, dest)
     except Exception as e:
         logging.error("Failed to copy file from %s to %s: %s", src, dest, e)


### PR DESCRIPTION
Replaces inefficient binary file copying with proper `shutil.copy2()` implementation in createbatch script.

## Changes
- Replace manual binary read/write with `shutil.copy2()`
- Preserve file metadata (timestamps, permissions)
- Add automatic destination directory creation
- Update docstring with Sphinx-style Args section
- Maintain existing function signature and error handling

## Benefits
- Memory efficient for large files
- Standard, well-tested implementation
- Consistent with other scripts in the codebase

Fixes #3

Generated with [Claude Code](https://claude.ai/code)