### PR TITLE
Fix: Process all photos before videos in givephotobankreadymediafiles

### DIFF
--- a/givephotobankreadymediafiles/givephotobankreadymediafileslib/media_processor.py
+++ b/givephotobankreadymediafiles/givephotobankreadymediafileslib/media_processor.py
@@ -9,20 +9,22 @@ from datetime import datetime
 from tqdm import tqdm
 
 from givephotobankreadymediafileslib.constants import (
-    COL_FILE, COL_PATH, COL_ORIGINAL, COL_CREATE_DATE, 
+    COL_FILE, COL_PATH, COL_ORIGINAL, COL_CREATE_DATE,
     COL_STATUS_SUFFIX, STATUS_UNPROCESSED, ORIGINAL_YES
 )
+from givephotobankreadymediafileslib.media_helper import get_media_type
 
 
 def find_unprocessed_records(records: List[Dict[str, str]]) -> List[Dict[str, str]]:
     """
     Find records that need processing (Originál=ano and any status=STATUS_UNPROCESSED).
-    
+
     Args:
         records: List of all media records
-        
+
     Returns:
-        List of unprocessed records, sorted by date and filename
+        List of unprocessed records, sorted by media type (images first, then videos),
+        then by creation date, then by filename
     """
     logging.info("Filtering unprocessed records")
     
@@ -48,26 +50,41 @@ def find_unprocessed_records(records: List[Dict[str, str]]) -> List[Dict[str, st
             else:
                 logging.warning(f"File not found, skipping: {file_path}")
     
-    # Sort by creation date (parsed as datetime) and filename, like PowerShell version
+    # Sort by media type (photos first, then videos), then by creation date, then by filename
     def sort_key(record):
+        # Get file path and media type
+        file_path = record.get(COL_PATH, "")
+        media_type = get_media_type(file_path) if file_path else "unknown"
+
+        # Media type priority: images (0) before videos (1), unknown last (2)
+        if media_type == "image":
+            type_priority = 0
+        elif media_type == "video":
+            type_priority = 1
+        else:
+            type_priority = 2
+
+        # Parse creation date
         date_str = record.get(COL_CREATE_DATE, "")
         if not date_str:
-            return (datetime.min, record.get(COL_FILE, ""))
-        
-        try:
-            # Format is DD.MM.YYYY or DD.MM.YYYY HH:MM:SS
-            if ' ' not in date_str:
-                # No time part, add 00:00:00
-                date_str += " 00:00:00"
-            
-            parsed_date = datetime.strptime(date_str, "%d.%m.%Y %H:%M:%S")
-        except ValueError:
-            # If parsing fails, use string comparison as fallback
             parsed_date = datetime.min
-            logging.warning(f"Could not parse date '{date_str}' for file {record.get(COL_FILE, 'Unknown')}")
-        
-        return (parsed_date, record.get(COL_FILE, ""))
-    
+        else:
+            try:
+                # Format is DD.MM.YYYY or DD.MM.YYYY HH:MM:SS
+                if ' ' not in date_str:
+                    # No time part, add 00:00:00
+                    date_str += " 00:00:00"
+
+                parsed_date = datetime.strptime(date_str, "%d.%m.%Y %H:%M:%S")
+            except ValueError:
+                # If parsing fails, use string comparison as fallback
+                parsed_date = datetime.min
+                logging.warning(f"Could not parse date '{date_str}' for file {record.get(COL_FILE, 'Unknown')}")
+
+        # Return tuple: (type_priority, date, filename)
+        # This ensures: all images sorted by date, then all videos sorted by date
+        return (type_priority, parsed_date, record.get(COL_FILE, ""))
+
     unprocessed.sort(key=sort_key)
     
     logging.info(f"Found {len(unprocessed)} unprocessed records")


### PR DESCRIPTION
## Summary
- Fixed sorting order to process all photos first (sorted by date), then all videos (sorted by date)
- Previously, videos could appear mixed with photos when sorted only by creation date
- Added media type priority to sorting key: images (0) → videos (1) → unknown (2)

## Changes
- Added `get_media_type()` import from `media_helper` module
- Modified `sort_key` function to return 3-tuple: `(type_priority, parsed_date, filename)`
- Updated docstring to reflect new sorting behavior

## Test plan
- [ ] Run `givephotobankreadymediafiles.py` on mixed media directory
- [ ] Verify all photos process before any videos
- [ ] Verify photos are sorted by date within their group
- [ ] Verify videos are sorted by date within their group

🤖 Generated with [Claude Code](https://claude.com/claude-code)