### PR TITLE
Fix empty progress bars in file operations (Issue #58)

### DIFF
--- a/exportpreparedmedia/shared/file_operations.py
+++ b/exportpreparedmedia/shared/file_operations.py
@@ -52,6 +52,10 @@ def copy_folder(src: str, dest: str, overwrite: bool = True, pattern: str = "") 
             regex = re.compile(pattern, re.IGNORECASE)
             files = [f for f in files if regex.search(os.path.basename(f))]
 
+        if not files:
+            logging.info("No files to copy from %s to %s", src, dest)
+            return
+
         for file_path in tqdm(files, desc="Copying folder", unit="file"):
             rel_path = os.path.relpath(file_path, src)
             dest_path = os.path.join(dest, rel_path)
@@ -94,6 +98,10 @@ def move_folder(src: str, dest: str, overwrite: bool = False, pattern: str = "")
         if pattern:
             regex = re.compile(pattern, re.IGNORECASE)
             files = [f for f in files if regex.search(os.path.basename(f))]
+
+        if not files:
+            logging.info("No files to move from %s to %s", src, dest)
+            return
 
         for file_path in tqdm(files, desc="Moving folder", unit="file"):
             rel_path = os.path.relpath(file_path, src)

--- a/givephotobankreadymediafiles/shared/file_operations.py
+++ b/givephotobankreadymediafiles/shared/file_operations.py
@@ -57,6 +57,10 @@ def copy_folder(src: str, dest: str, overwrite: bool = True, pattern: str = "") 
             regex = re.compile(pattern, re.IGNORECASE)
             files = [f for f in files if regex.search(os.path.basename(f))]
 
+        if not files:
+            logging.info("No files to copy from %s to %s", src, dest)
+            return
+
         for file_path in tqdm(files, desc="Copying folder", unit="file"):
             rel_path = os.path.relpath(file_path, src)
             dest_path = os.path.join(dest, rel_path)
@@ -99,6 +103,10 @@ def move_folder(src: str, dest: str, overwrite: bool = False, pattern: str = "")
         if pattern:
             regex = re.compile(pattern, re.IGNORECASE)
             files = [f for f in files if regex.search(os.path.basename(f))]
+
+        if not files:
+            logging.info("No files to move from %s to %s", src, dest)
+            return
 
         for file_path in tqdm(files, desc="Moving folder", unit="file"):
             rel_path = os.path.relpath(file_path, src)

--- a/integratesortedphotos/integratesortedphotoslib/copy_files.py
+++ b/integratesortedphotos/integratesortedphotoslib/copy_files.py
@@ -21,6 +21,10 @@ def copy_files_with_preserved_dates(src_folder, dest_folder):
                 dest_file = os.path.join(dest_folder, rel_path, file)
                 all_files.append((src_file, dest_file))
 
+        if not all_files:
+            logging.info("No files to copy from %s to %s", src_folder, dest_folder)
+            return
+
         # Copy files with progress bar
         with tqdm(total=len(all_files), desc="Copying files", unit="file") as pbar:
             for src_file, dest_file in all_files:

--- a/launchphotobanks/shared/file_operations.py
+++ b/launchphotobanks/shared/file_operations.py
@@ -51,6 +51,10 @@ def copy_folder(src: str, dest: str, overwrite: bool = True, pattern: str = "") 
             regex = re.compile(pattern, re.IGNORECASE)
             files = [f for f in files if regex.search(os.path.basename(f))]
 
+        if not files:
+            logging.info("No files to copy from %s to %s", src, dest)
+            return
+
         for file_path in tqdm(files, desc="Copying folder", unit="file"):
             rel_path = os.path.relpath(file_path, src)
             dest_path = os.path.join(dest, rel_path)
@@ -93,6 +97,10 @@ def move_folder(src: str, dest: str, overwrite: bool = False, pattern: str = "")
         if pattern:
             regex = re.compile(pattern, re.IGNORECASE)
             files = [f for f in files if regex.search(os.path.basename(f))]
+
+        if not files:
+            logging.info("No files to move from %s to %s", src, dest)
+            return
 
         for file_path in tqdm(files, desc="Moving folder", unit="file"):
             rel_path = os.path.relpath(file_path, src)

--- a/markmediaaschecked/shared/file_operations.py
+++ b/markmediaaschecked/shared/file_operations.py
@@ -57,6 +57,10 @@ def copy_folder(src: str, dest: str, overwrite: bool = True, pattern: str = "") 
             regex = re.compile(pattern, re.IGNORECASE)
             files = [f for f in files if regex.search(os.path.basename(f))]
 
+        if not files:
+            logging.info("No files to copy from %s to %s", src, dest)
+            return
+
         for file_path in tqdm(files, desc="Copying folder", unit="file"):
             rel_path = os.path.relpath(file_path, src)
             dest_path = os.path.join(dest, rel_path)
@@ -99,6 +103,10 @@ def move_folder(src: str, dest: str, overwrite: bool = False, pattern: str = "")
         if pattern:
             regex = re.compile(pattern, re.IGNORECASE)
             files = [f for f in files if regex.search(os.path.basename(f))]
+
+        if not files:
+            logging.info("No files to move from %s to %s", src, dest)
+            return
 
         for file_path in tqdm(files, desc="Moving folder", unit="file"):
             rel_path = os.path.relpath(file_path, src)

--- a/markphotomediaapprovalstatus/shared/file_operations.py
+++ b/markphotomediaapprovalstatus/shared/file_operations.py
@@ -57,6 +57,10 @@ def copy_folder(src: str, dest: str, overwrite: bool = True, pattern: str = "") 
             regex = re.compile(pattern, re.IGNORECASE)
             files = [f for f in files if regex.search(os.path.basename(f))]
 
+        if not files:
+            logging.info("No files to copy from %s to %s", src, dest)
+            return
+
         for file_path in tqdm(files, desc="Copying folder", unit="file"):
             rel_path = os.path.relpath(file_path, src)
             dest_path = os.path.join(dest, rel_path)
@@ -99,6 +103,10 @@ def move_folder(src: str, dest: str, overwrite: bool = False, pattern: str = "")
         if pattern:
             regex = re.compile(pattern, re.IGNORECASE)
             files = [f for f in files if regex.search(os.path.basename(f))]
+
+        if not files:
+            logging.info("No files to move from %s to %s", src, dest)
+            return
 
         for file_path in tqdm(files, desc="Moving folder", unit="file"):
             rel_path = os.path.relpath(file_path, src)

--- a/pullnewmediatounsorted/shared/file_operations.py
+++ b/pullnewmediatounsorted/shared/file_operations.py
@@ -51,6 +51,10 @@ def copy_folder(src: str, dest: str, overwrite: bool = True, pattern: str = "") 
             regex = re.compile(pattern, re.IGNORECASE)
             files = [f for f in files if regex.search(os.path.basename(f))]
 
+        if not files:
+            logging.info("No files to copy from %s to %s", src, dest)
+            return
+
         for file_path in tqdm(files, desc="Copying folder", unit="file"):
             rel_path = os.path.relpath(file_path, src)
             dest_path = os.path.join(dest, rel_path)
@@ -93,6 +97,10 @@ def move_folder(src: str, dest: str, overwrite: bool = False, pattern: str = "")
         if pattern:
             regex = re.compile(pattern, re.IGNORECASE)
             files = [f for f in files if regex.search(os.path.basename(f))]
+
+        if not files:
+            logging.info("No files to move from %s to %s", src, dest)
+            return
 
         for file_path in tqdm(files, desc="Moving folder", unit="file"):
             rel_path = os.path.relpath(file_path, src)

--- a/removealreadysortedout/shared/file_operations.py
+++ b/removealreadysortedout/shared/file_operations.py
@@ -51,6 +51,10 @@ def copy_folder(src: str, dest: str, overwrite: bool = True, pattern: str = "") 
             regex = re.compile(pattern, re.IGNORECASE)
             files = [f for f in files if regex.search(os.path.basename(f))]
 
+        if not files:
+            logging.info("No files to copy from %s to %s", src, dest)
+            return
+
         for file_path in tqdm(files, desc="Copying folder", unit="file"):
             rel_path = os.path.relpath(file_path, src)
             dest_path = os.path.join(dest, rel_path)
@@ -93,6 +97,10 @@ def move_folder(src: str, dest: str, overwrite: bool = False, pattern: str = "")
         if pattern:
             regex = re.compile(pattern, re.IGNORECASE)
             files = [f for f in files if regex.search(os.path.basename(f))]
+
+        if not files:
+            logging.info("No files to move from %s to %s", src, dest)
+            return
 
         for file_path in tqdm(files, desc="Moving folder", unit="file"):
             rel_path = os.path.relpath(file_path, src)

--- a/sortunsortedmedia/shared/file_operations.py
+++ b/sortunsortedmedia/shared/file_operations.py
@@ -51,6 +51,10 @@ def copy_folder(src: str, dest: str, overwrite: bool = True, pattern: str = "") 
             regex = re.compile(pattern, re.IGNORECASE)
             files = [f for f in files if regex.search(os.path.basename(f))]
 
+        if not files:
+            logging.info("No files to copy from %s to %s", src, dest)
+            return
+
         for file_path in tqdm(files, desc="Copying folder", unit="file"):
             rel_path = os.path.relpath(file_path, src)
             dest_path = os.path.join(dest, rel_path)
@@ -93,6 +97,10 @@ def move_folder(src: str, dest: str, overwrite: bool = False, pattern: str = "")
         if pattern:
             regex = re.compile(pattern, re.IGNORECASE)
             files = [f for f in files if regex.search(os.path.basename(f))]
+
+        if not files:
+            logging.info("No files to move from %s to %s", src, dest)
+            return
 
         for file_path in tqdm(files, desc="Moving folder", unit="file"):
             rel_path = os.path.relpath(file_path, src)

--- a/updatemediadatabase/shared/file_operations.py
+++ b/updatemediadatabase/shared/file_operations.py
@@ -52,6 +52,10 @@ def copy_folder(src: str, dest: str, overwrite: bool = True, pattern: str = "") 
             regex = re.compile(pattern, re.IGNORECASE)
             files = [f for f in files if regex.search(os.path.basename(f))]
 
+        if not files:
+            logging.info("No files to copy from %s to %s", src, dest)
+            return
+
         for file_path in tqdm(files, desc="Copying folder", unit="file"):
             rel_path = os.path.relpath(file_path, src)
             dest_path = os.path.join(dest, rel_path)
@@ -94,6 +98,10 @@ def move_folder(src: str, dest: str, overwrite: bool = False, pattern: str = "")
         if pattern:
             regex = re.compile(pattern, re.IGNORECASE)
             files = [f for f in files if regex.search(os.path.basename(f))]
+
+        if not files:
+            logging.info("No files to move from %s to %s", src, dest)
+            return
 
         for file_path in tqdm(files, desc="Moving folder", unit="file"):
             rel_path = os.path.relpath(file_path, src)


### PR DESCRIPTION
## Summary
Fixes empty progress bars appearing when there are no files to process in file operations.

## Changes
- Added early return checks before tqdm() progress bar creation in 10 files
- Functions now log informative messages instead of showing empty progress bars

## Affected Functions
- `copy_folder()` in 9 shared/file_operations.py files
- `move_folder()` in 9 shared/file_operations.py files  
- `copy_files_with_preserved_dates()` in integratesortedphotos/copy_files.py

## Issue
Resolves #58

## Test Plan
No files to process → logs message "No files to copy/move" and returns early without showing progress bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)