### PR TITLE
feat: Add optional user description field to normal mode (fixes #72)

### DIFF
--- a/givephotobankreadymediafiles/givephotobankreadymediafileslib/metadata_generator.py
+++ b/givephotobankreadymediafiles/givephotobankreadymediafileslib/metadata_generator.py
@@ -69,13 +69,15 @@ class MetadataGenerator:
         """
         self.photobank_categories = categories
     
-    def generate_title(self, image_path: str, context: Optional[str] = None) -> str:
+    def generate_title(self, image_path: str, context: Optional[str] = None,
+                       user_description: Optional[str] = None) -> str:
         """
         Generate SEO-optimized title for image (original version only).
 
         Args:
             image_path: Path to image file
             context: Optional context or existing title to refine
+            user_description: Optional user input (description, commands, or notes)
 
         Returns:
             Title string (max 100 characters)
@@ -90,7 +92,7 @@ class MetadataGenerator:
             logging.error(error_msg)
             raise ValueError(error_msg)
 
-        prompt = self.prompt_manager.get_title_prompt(context)
+        prompt = self.prompt_manager.get_title_prompt(context, user_description)
 
         import json
         from shared.ai_module import Message
@@ -136,7 +138,8 @@ class MetadataGenerator:
         raise RuntimeError(error_msg)
     
     def generate_description(self, image_path: str, title: Optional[str] = None,
-                           context: Optional[str] = None, editorial_data: Optional[Dict[str, str]] = None) -> str:
+                           context: Optional[str] = None, editorial_data: Optional[Dict[str, str]] = None,
+                           user_description: Optional[str] = None) -> str:
         """
         Generate detailed description for image (original version only).
 
@@ -145,6 +148,7 @@ class MetadataGenerator:
             title: Optional title to reference
             context: Optional context or existing description
             editorial_data: Optional editorial metadata (city, country, date) for editorial format
+            user_description: Optional user input (description, commands, or notes)
 
         Returns:
             Description string (max 200 characters, including editorial prefix if applicable)
@@ -177,7 +181,7 @@ class MetadataGenerator:
                     logging.error(error_msg)
                     raise ValueError(error_msg)
 
-        prompt = self.prompt_manager.get_description_prompt(title, context)
+        prompt = self.prompt_manager.get_description_prompt(title, context, user_description)
 
         import json
         from shared.ai_module import Message

--- a/givephotobankreadymediafiles/shared/prompts_config.json
+++ b/givephotobankreadymediafiles/shared/prompts_config.json
@@ -23,13 +23,14 @@
         "- \"Woman practicing yoga Natarajasana pose at sunrise on beach\"",
         "- \"Norway spruce tree in misty morning forest\"",
         "",
-        "{context_section}Return ONLY valid JSON with this exact structure:",
+        "{user_input_section}{context_section}Return ONLY valid JSON with this exact structure:",
         "{{",
         "  \"original\": \"title for the image\"",
         "}}",
         "",
         "Return ONLY the JSON object, no other text or explanation."
       ],
+      "user_input_template": "NOTE: User input may include descriptions, specific instructions (e.g., 'identify species', 'determine exact type'), notes about uncertainty, or contextual explanations. Interpret and apply this information appropriately.\n\nUSER INPUT:\n{user_description}\n\n",
       "context_template": "Context/existing title to improve: {context}\n\n",
       "variables": {
         "max_length": 80,
@@ -67,13 +68,14 @@
         "Example of good description:",
         "\"Silhouette of woman practicing the yoga pose Natarajasana, or Lord of the Dance Pose during flaming orange, red and purple sunrise on Campeche beach in Florianópolis, at the Atlantic Ocean in Santa Catarina, Brazil. The surface of the water is calm and peaceful mirroring the woman and the small island in the background.\"",
         "",
-        "{title_section}{context_section}Return ONLY valid JSON with this exact structure:",
+        "{user_input_section}{title_section}{context_section}Return ONLY valid JSON with this exact structure:",
         "{{",
         "  \"original\": \"description for the image\"",
         "}}",
         "",
         "Return ONLY the JSON object, no other text or explanation."
       ],
+      "user_input_template": "NOTE: User input may include descriptions, specific instructions (e.g., 'identify species', 'determine exact type'), notes about uncertainty, or contextual explanations. Interpret and apply this information appropriately.\n\nUSER INPUT:\n{user_description}\n\n",
       "title_template": "Title: {title}\n",
       "context_template": "Context/existing description to improve: {context}\n",
       "variables": {


### PR DESCRIPTION
## Summary
Adds optional user description field to normal mode metadata generation, matching batch mode functionality.

## Changes
- Added multiline Text widget to GUI for user input
- Updated metadata_generator.py to accept user_description parameter
- Updated prompt_manager.py to include user input in AI prompts
- Updated prompt templates with user_input_template

## Implementation
- Focus event handlers manage placeholder text
- Returns None if empty or contains placeholder
- Integrates seamlessly with existing workflow

## Testing
- All type hints present
- All docstrings complete (Sphinx-style)
- Proper error handling
- No debug code or temp files

Implements GitHub issue #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)