### PR TITLE
fix: Restrict Dreamstime CSV export to JPG format only

### DIFF
--- a/exportpreparedmedia/exportpreparedmedialib/constants.py
+++ b/exportpreparedmedia/exportpreparedmedialib/constants.py
@@ -68,6 +68,12 @@ FORMAT_SUBDIRS = {
     **{ext: 'RAW' for ext in RAW_FORMATS}
 }
 
+# Export-specific format restrictions (overrides PHOTOBANK_SUPPORTED_FORMATS for CSV export)
+# Banks not listed here use PHOTOBANK_SUPPORTED_FORMATS
+PHOTOBANK_EXPORT_FORMATS = {
+    'DreamsTime': {'.jpg'},  # DreamsTime accepts JPG, PNG, RAW in portal but only JPG in CSV import
+}
+
 # File numbering system constants
 MIN_NUMBER_WIDTH = 4  # Minimum width for backward compatibility with existing files
 MAX_NUMBER_WIDTH = 6  # Maximum width for new capacity

--- a/exportpreparedmedia/exportpreparedmedialib/exporters.py
+++ b/exportpreparedmedia/exportpreparedmedialib/exporters.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from shared.file_operations import save_csv
 from shared.csv_sanitizer import sanitize_field
 from exportpreparedmedialib.column_maps import get_column_map
-from exportpreparedmedialib.constants import PHOTOBANK_SUPPORTED_FORMATS, FORMAT_SUBDIRS
+from exportpreparedmedialib.constants import PHOTOBANK_SUPPORTED_FORMATS, PHOTOBANK_EXPORT_FORMATS, FORMAT_SUBDIRS
 
 
 def expand_item_with_alternative_formats(item: Dict[str, str], bank: str, include_alternatives: bool = False) -> List[Dict[str, str]]:
@@ -33,7 +33,9 @@ def expand_item_with_alternative_formats(item: Dict[str, str], bank: str, includ
     source_ext = source_path.suffix.lower()
 
     # Get supported formats for this bank
-    supported_formats = PHOTOBANK_SUPPORTED_FORMATS.get(bank, {'.jpg'})
+    # Check export-specific formats first, fall back to general formats
+    supported_formats = PHOTOBANK_EXPORT_FORMATS.get(bank, PHOTOBANK_SUPPORTED_FORMATS.get(bank, {'.jpg'}))
+    logging.debug(f"Using export formats for {bank}: {supported_formats}")
 
     # Add source file only if its format is supported by this bank
     if source_ext in supported_formats:


### PR DESCRIPTION
## Summary

Restrict Dreamstime CSV export to JPG format only, while keeping PNG/RAW support in createbatch.

## Changes

- **exportpreparedmedia/exportpreparedmedialib/constants.py**: Added `PHOTOBANK_EXPORT_FORMATS` constant for export-specific format restrictions
- **exportpreparedmedia/exportpreparedmedialib/exporters.py**: Modified `expand_item_with_alternative_formats()` to check export-specific formats first

## Technical Details

DreamsTime portal accepts JPG, PNG, and RAW formats for direct upload, but CSV import functionality only supports JPG. This change:

1. Introduces `PHOTOBANK_EXPORT_FORMATS` dictionary that overrides `PHOTOBANK_SUPPORTED_FORMATS` for CSV export operations
2. Keeps PNG/RAW in `PHOTOBANK_SUPPORTED_FORMATS` so createbatch can still copy these files
3. Export CSV will now filter out PNG/RAW entries for DreamsTime

## Testing

### Expected behavior:
- **CreateBatch**: Still copies JPG, PNG, and RAW files to Dreamstime folders (unchanged)
- **Export CSV**: Only includes JPG entries for DreamsTime (PNG/RAW filtered out)
- **Other banks**: No change in behavior

### Test cases needed:
- Export with DreamsTime enabled, mixed JPG/PNG/RAW in PhotoMedia.csv → CSV should contain only JPG
- CreateBatch with DreamsTime should still process PNG/RAW files
- Other photobanks should remain unaffected

## Related

Part of photobank-specific format requirements implementation. DreamsTime CSV import has stricter format requirements than portal upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)