### PR TITLE
feat: Add batch size limit of 128 for Getty Images

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,11 @@ They are **shared** across all modules; local specifics may be added at script l
 
   * Always under result folder defined in `constants.py` (overridable by CLI arg).
   * Folder structure and filenames must follow fixed convention (`<BankName>Output.csv/json`).
-  * No other names allowed.
+  * **Exception for batch splitting:** Banks with batch size limits create numbered files:
+    - Example: `GettyImagesOutput_1.csv`, `GettyImagesOutput_2.csv`
+    - Each file contains maximum items per bank's batch size limit
+    - Subfolder structure: `GettyImages/batch_001/`, `GettyImages/batch_002/`
+  * No other naming variations allowed.
 
 ---
 

--- a/createbatch/createbatchlib/constants.py
+++ b/createbatch/createbatchlib/constants.py
@@ -57,3 +57,9 @@ ALTERNATIVE_EDIT_TAGS = {
     "_misty": "Misty/foggy effect",
     "_blurred": "Gaussian blur"
 }
+
+# Batch size limits for photobanks (items per batch)
+# Banks not listed here have no batch size limit
+PHOTOBANK_BATCH_SIZE_LIMITS = {
+    'Getty Images': 128,  # Note: Inconsistent naming with export ('GettyImages')
+}

--- a/createbatch/createbatchlib/media_preparation.py
+++ b/createbatch/createbatchlib/media_preparation.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Dict, List
+from typing import Dict, List, Optional
 from pathlib import Path
 from shared.file_operations import ensure_directory, copy_file
 from shared.exif_handler import update_exif_metadata
@@ -10,18 +10,44 @@ from createbatchlib.constants import (
     PHOTOBANK_SUPPORTED_FORMATS, FORMAT_SUBDIRS, ALTERNATIVE_EDIT_TAGS
 )
 
+
+def split_into_batches(records: List[Dict[str, str]], batch_size: int) -> List[List[Dict[str, str]]]:
+    """
+    Split records into batches of specified size.
+
+    Args:
+        records: List of records to split
+        batch_size: Maximum number of records per batch
+
+    Returns:
+        List of batches (each batch is a list of records)
+    """
+    if batch_size <= 0:
+        return [records]  # No splitting
+
+    batches = []
+    for i in range(0, len(records), batch_size):
+        batch = records[i:i + batch_size]
+        batches.append(batch)
+
+    logging.info(f"Split {len(records)} records into {len(batches)} batches of max {batch_size} items")
+    return batches
+
+
 def prepare_media_file(
     record: Dict[str, str],
     output_folder: str,
     exif_tool_path: str,
     overwrite: bool = True,
     bank: str = None,
-    include_alternative_formats: bool = False
+    include_alternative_formats: bool = False,
+    batch_number: Optional[int] = None
 ) -> List[str]:
     """
     Copy a media file into output_folder/<photobank>/<format>/ and update its EXIF metadata.
     If 'bank' is specified, only files for that photobank are processed.
     If include_alternative_formats is True, also copy alternative format versions (PNG, TIFF, RAW).
+    If batch_number is specified, files are copied to output_folder/<photobank>/batch_XXX/<format>/.
 
     Returns a list of paths where the file was copied.
     """
@@ -74,8 +100,15 @@ def prepare_media_file(
                 # Create edit subfolder (original or tag)
                 edit_subfolder = edit_tag if edit_tag else 'original'
 
-                # Create destination path: output_folder/BankName/format/edit/filename
-                bank_folder = os.path.join(output_folder, bank_name, format_subdir, edit_subfolder)
+                # Create destination path
+                if batch_number is not None:
+                    # Create batch subfolder: output_folder/BankName/batch_001/format/edit/filename
+                    batch_folder = f"batch_{batch_number:03d}"  # Format: batch_001, batch_002, etc.
+                    bank_folder = os.path.join(output_folder, bank_name, batch_folder, format_subdir, edit_subfolder)
+                else:
+                    # Original path: output_folder/BankName/format/edit/filename
+                    bank_folder = os.path.join(output_folder, bank_name, format_subdir, edit_subfolder)
+
                 ensure_directory(bank_folder)
                 dest = os.path.join(bank_folder, filename)
 

--- a/createbatch/createbatchlib/media_preparation.py
+++ b/createbatch/createbatchlib/media_preparation.py
@@ -22,7 +22,13 @@ def split_into_batches(records: List[Dict[str, str]], batch_size: int) -> List[L
     Returns:
         List of batches (each batch is a list of records)
     """
+    # Handle empty input
+    if not records:
+        logging.warning("split_into_batches called with empty records list")
+        return []
+
     if batch_size <= 0:
+        logging.warning(f"Invalid batch_size {batch_size}, treating as unlimited")
         return [records]  # No splitting
 
     batches = []

--- a/exportpreparedmedia/exportpreparedmedialib/constants.py
+++ b/exportpreparedmedia/exportpreparedmedialib/constants.py
@@ -110,3 +110,9 @@ PHOTOBANKS = [
     "Alamy",
     "GettyImages"
 ]
+
+# Batch size limits for photobanks (items per batch)
+# Banks not listed here have no batch size limit
+PHOTOBANK_BATCH_SIZE_LIMITS = {
+    'GettyImages': 128,
+}

--- a/exportpreparedmedia/exportpreparedmedialib/exporters.py
+++ b/exportpreparedmedia/exportpreparedmedialib/exporters.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from shared.file_operations import save_csv
 from shared.csv_sanitizer import sanitize_field
 from exportpreparedmedialib.column_maps import get_column_map
-from exportpreparedmedialib.constants import PHOTOBANK_SUPPORTED_FORMATS, FORMAT_SUBDIRS
+from exportpreparedmedialib.constants import PHOTOBANK_SUPPORTED_FORMATS, PHOTOBANK_BATCH_SIZE_LIMITS, FORMAT_SUBDIRS
 
 
 def expand_item_with_alternative_formats(item: Dict[str, str], bank: str, include_alternatives: bool = False) -> List[Dict[str, str]]:
@@ -318,37 +318,8 @@ def export_to_photobanks(items: List[Dict[str, str]], enabled_banks: List[str], 
         output_file = output_paths[bank]
         logging.debug(f"Processing bank: {bank}, output file: {output_file}")
 
-        # Zápis hlavičky
-        try:
-            bank_format = export_formats.get(bank, {})
-            header = bank_format.get('headers', '')
-            delimiter = bank_format.get('delimiter', ',')
-
-            # Oddělovač by měl být již převeden na skutečný znak v load_photobank_headers
-            if delimiter == '\t':
-                logging.debug(f"Using TAB delimiter for {bank} header")
-            else:
-                logging.debug(f"Using delimiter for {bank} header: '{delimiter}'")
-
-            logging.debug(f"Bank format for {bank}:\n{json.dumps(bank_format, indent=2)}")
-
-            if header:
-                logging.debug(f"Writing header to file: {output_file}")
-                logging.debug(f"Header content: {repr(header)}")
-                with open(output_file, 'w', encoding='utf-8') as f:
-                    f.write(header + '\n')
-                logging.debug(f"Wrote header for {bank}")
-                logging.debug(f"File exists after header write: {os.path.exists(output_file)}")
-                logging.debug(f"File size after header write: {os.path.getsize(output_file)} bytes")
-            else:
-                logging.warning(f"No header defined for {bank}")
-        except Exception as e:
-            logging.error(f"Failed to write header for {bank}: {e}")
-            logging.debug(f"Exception details: {str(e)}", exc_info=True)
-
-        # Export záznamů
-        export_count = 0
-        attempted_count = 0
+        # Check if bank has batch size limit
+        batch_size_limit = PHOTOBANK_BATCH_SIZE_LIMITS.get(bank, 0)
 
         # Filtruj položky podle banky, pokud je zadána filtrovací funkce
         bank_items = items
@@ -356,26 +327,58 @@ def export_to_photobanks(items: List[Dict[str, str]], enabled_banks: List[str], 
             bank_items = [item for item in items if filter_func(item, bank)]
             logging.info(f"Filtered {len(bank_items)}/{len(items)} items for {bank} based on status")
 
-        # Pro každou položku vytvoř rozšířený záznam a exportuj ho
+        # Expand to alternative formats and create records
+        all_records = []
         for item in bank_items:
-            # Expand to alternative formats if supported by this bank
             expanded_items = expand_item_with_alternative_formats(item, bank, include_alternative_formats)
-
             for expanded_item in expanded_items:
-                attempted_count += 1
-                # Vytvoření rozšířeného záznamu pro aktuální položku
                 record = extract_media_properties(expanded_item, category_maps, pond_prices)
+                all_records.append(record)
 
-                if export_mediafile(bank, record, output_file, export_formats):
+        logging.info(f"{bank}: {len(all_records)} total records after format expansion")
+
+        # Split into batches if needed
+        if batch_size_limit > 0 and len(all_records) > batch_size_limit:
+            batches = [all_records[i:i + batch_size_limit] for i in range(0, len(all_records), batch_size_limit)]
+            logging.info(f"{bank} has batch size limit of {batch_size_limit}, splitting into {len(batches)} files")
+        else:
+            batches = [all_records]
+
+        # Process each batch
+        for batch_idx, batch_records in enumerate(batches, start=1):
+            # Determine output file path
+            if len(batches) > 1:
+                # Multiple batches: add suffix _1, _2, etc.
+                output_path = Path(output_file)
+                batch_output_file = str(output_path.parent / f"{output_path.stem}_{batch_idx}{output_path.suffix}")
+            else:
+                # Single batch: use original filename
+                batch_output_file = output_file
+
+            logging.info(f"Writing batch {batch_idx}/{len(batches)} to {batch_output_file}")
+
+            # Write header
+            try:
+                bank_format = export_formats.get(bank, {})
+                header = bank_format.get('headers', '')
+                delimiter = bank_format.get('delimiter', ',')
+
+                if header:
+                    with open(batch_output_file, 'w', encoding='utf-8') as f:
+                        f.write(header + '\n')
+                    logging.debug(f"Wrote header for {bank} batch {batch_idx}")
+                else:
+                    logging.warning(f"No header defined for {bank}")
+            except Exception as e:
+                logging.error(f"Failed to write header for {bank} batch {batch_idx}: {e}")
+                continue
+
+            # Export records in this batch
+            export_count = 0
+            for record in batch_records:
+                if export_mediafile(bank, record, batch_output_file, export_formats):
                     export_count += 1
                     if export_count % 10 == 0:
-                        logging.debug(f"Successfully exported {export_count}/{attempted_count} records to {bank} (total items: {len(items)})")
+                        logging.debug(f"Batch {batch_idx}: exported {export_count}/{len(batch_records)} records")
 
-        if attempted_count > 0:
-            logging.info(f"Exported {export_count}/{attempted_count} records to {bank} (success rate: {export_count/attempted_count*100:.1f}%)")
-        else:
-            logging.info(f"No records found for {bank} - skipping export")
-        if os.path.exists(output_file):
-            logging.debug(f"Final file size for {bank}: {os.path.getsize(output_file)} bytes")
-        else:
-            logging.warning(f"Output file for {bank} does not exist after export: {output_file}")
+            logging.info(f"Batch {batch_idx}: exported {export_count}/{len(batch_records)} records to {batch_output_file}")


### PR DESCRIPTION
## Summary

Add automatic batch splitting for Getty Images to comply with their 128-item submission limit. Affects both createbatch (subfolder creation) and export (CSV file splitting).

## Changes

### Constants
- **exportpreparedmedia/exportpreparedmedialib/constants.py**: Added `PHOTOBANK_BATCH_SIZE_LIMITS` with Getty Images limit of 128
- **createbatch/createbatchlib/constants.py**: Added `PHOTOBANK_BATCH_SIZE_LIMITS` with Getty Images limit of 128

### CreateBatch Module
- **createbatch/createbatchlib/media_preparation.py**: 
  - Added `split_into_batches()` utility function for chunking records
  - Modified `prepare_media_file()` to accept optional `batch_number` parameter
  - Updated destination path logic to create batch subfolders (batch_001, batch_002, etc.)
  
- **createbatch/createbatch.py**:
  - Added batch splitting logic to main processing loop
  - Getty Images records are split into 128-item batches before processing
  - Each batch gets separate subfolder: `GettyImages/batch_001/jpg/original/`

### Export Module
- **exportpreparedmedia/exportpreparedmedialib/exporters.py**:
  - Modified `export_to_photobanks()` to check batch size limits
  - Automatic CSV file splitting for banks exceeding limit
  - Multiple CSV files with suffixes: `CSV_GettyImages_1.csv`, `CSV_GettyImages_2.csv`

## Technical Details

### CreateBatch Folder Structure

**Before:**
```
GettyImages/
├── jpg/
│   ├── original/
│   │   └── ... (all 200 files)
```

**After:**
```
GettyImages/
├── batch_001/
│   ├── jpg/
│   │   ├── original/
│   │   │   └── ... (files 1-128)
├── batch_002/
│   ├── jpg/
│   │   ├── original/
│   │   │   └── ... (files 129-200)
```

### Export CSV Files

**Before:**
```
CSV_GettyImages.csv (all 200 rows)
```

**After:**
```
CSV_GettyImages_1.csv (rows 1-128)
CSV_GettyImages_2.csv (rows 129-200)
```

## Testing

### Expected behavior:
- **Getty Images with 129 items**:
  - CreateBatch creates `GettyImages/batch_001/` and `GettyImages/batch_002/` folders
  - Export creates `CSV_GettyImages_1.csv` (128 rows) and `CSV_GettyImages_2.csv` (1 row)
- **Getty Images with 128 items**: Single batch (no splitting)
- **Other photobanks**: No change in behavior

### Test cases needed:
- CreateBatch with exactly 128 Getty items → verify single batch folder
- CreateBatch with 129 Getty items → verify 2 batch folders (128 + 1)
- Export with 256 Getty items → verify 2 CSV files of 128 rows each
- Verify other photobanks remain unaffected

## Notes

- **Bank naming inconsistency**: Export uses `'GettyImages'` while createbatch uses `'Getty Images'` (with space) - maintained for backward compatibility
- **No breaking changes**: Other photobanks unaffected by batch splitting
- **Follows existing patterns**: Uses same batch splitting pattern as `batch_manager.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)