### PR TITLE
Tighten Dreamstime category selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,8 @@ fix_*.ps1
 
 # Claude Code local settings
 .claude/settings.local.json
+.claude/*.md
+.claude/skills/
 
 # Build artifacts
 build/
@@ -70,6 +72,10 @@ htmlcov/
 *.csv.bak
 *.json.bak
 backup_*
+
+# Local notes
+PR_69_ISSUES.md
+.github/issues/issue_csv_backup_naming_convention_consistency.md
 
 # CUDA/GPU artifacts
 

--- a/createbatch/tests/integration/test_createbatch__pipeline_calls.py
+++ b/createbatch/tests/integration/test_createbatch__pipeline_calls.py
@@ -1,0 +1,71 @@
+"""
+Integration tests for createbatch main pipeline.
+"""
+
+import types
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "createbatch"
+sys.path.insert(0, str(package_root))
+
+import createbatch
+
+
+class DummyProcessor:
+    def __init__(self, *_a, **_k):
+        pass
+
+    def process_records_optimized(self, _records, include_edited=False):
+        return {"ShutterStock": [{"Cesta": "a.jpg"}, {"Cesta": "b.jpg"}]}
+
+
+class DummyProgress:
+    def __init__(self, _banks, _records_per_bank):
+        pass
+
+    def start_bank(self, _bank):
+        pass
+
+    def update_progress(self, _count):
+        pass
+
+    def finish_bank(self):
+        pass
+
+    def finish_all(self):
+        pass
+
+
+def test_main_processes_records(monkeypatch):
+    args = types.SimpleNamespace(
+        photo_csv="X:/photo.csv",
+        output_folder="X:/out",
+        overwrite=False,
+        log_dir="X:/logs",
+        debug=False,
+        include_edited=False,
+        include_alternative_formats=False,
+    )
+
+    called = {"prepare": 0}
+
+    monkeypatch.setattr(createbatch, "parse_arguments", lambda: args)
+    monkeypatch.setattr(createbatch, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(createbatch, "get_log_filename", lambda _p: "log.txt")
+    monkeypatch.setattr(createbatch, "setup_logging", lambda **_k: None)
+    monkeypatch.setattr(createbatch, "ensure_exiftool", lambda: "exiftool")
+    monkeypatch.setattr(createbatch, "load_csv", lambda _p: [{"Cesta": "a.jpg"}])
+    monkeypatch.setattr(createbatch, "RecordProcessor", DummyProcessor)
+    monkeypatch.setattr(createbatch, "UnifiedProgressTracker", DummyProgress)
+    monkeypatch.setattr(createbatch, "split_into_batches", lambda records, _limit: [records])
+
+    def fake_prepare(*_a, **_k):
+        called["prepare"] += 1
+        return ["out.jpg"]
+
+    monkeypatch.setattr(createbatch, "prepare_media_file", fake_prepare)
+
+    createbatch.main()
+    assert called["prepare"] == 2

--- a/createbatch/tests/security/test_createbatch__no_records.py
+++ b/createbatch/tests/security/test_createbatch__no_records.py
@@ -1,0 +1,47 @@
+"""
+Security-focused tests for createbatch no-records path.
+"""
+
+import types
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "createbatch"
+sys.path.insert(0, str(package_root))
+
+import createbatch
+
+
+class DummyProcessor:
+    def __init__(self, *_a, **_k):
+        pass
+
+    def process_records_optimized(self, _records, include_edited=False):
+        return {}
+
+
+def test_main_exits_when_no_records(monkeypatch):
+    args = types.SimpleNamespace(
+        photo_csv="X:/photo.csv",
+        output_folder="X:/out",
+        overwrite=False,
+        log_dir="X:/logs",
+        debug=False,
+        include_edited=False,
+        include_alternative_formats=False,
+    )
+
+    called = {"prepare": False}
+
+    monkeypatch.setattr(createbatch, "parse_arguments", lambda: args)
+    monkeypatch.setattr(createbatch, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(createbatch, "get_log_filename", lambda _p: "log.txt")
+    monkeypatch.setattr(createbatch, "setup_logging", lambda **_k: None)
+    monkeypatch.setattr(createbatch, "ensure_exiftool", lambda: "exiftool")
+    monkeypatch.setattr(createbatch, "load_csv", lambda _p: [])
+    monkeypatch.setattr(createbatch, "RecordProcessor", DummyProcessor)
+    monkeypatch.setattr(createbatch, "prepare_media_file", lambda *_a, **_k: called.__setitem__("prepare", True))
+
+    createbatch.main()
+    assert called["prepare"] is False

--- a/createbatch/tests/unit/test_constants__sanity.py
+++ b/createbatch/tests/unit/test_constants__sanity.py
@@ -1,0 +1,34 @@
+"""
+Unit tests for createbatchlib.constants values.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+createbatch_root = project_root / "createbatch"
+sys.path.insert(0, str(createbatch_root))
+
+from createbatchlib import constants
+
+
+def test_constants__expected_types():
+    assert isinstance(constants.DEFAULT_PHOTO_CSV_FILE, str)
+    assert isinstance(constants.DEFAULT_PROCESSED_MEDIA_FOLDER, str)
+    assert isinstance(constants.DEFAULT_LOG_DIR, str)
+    assert isinstance(constants.STATUS_FIELD_KEYWORD, str)
+    assert isinstance(constants.PREPARED_STATUS_VALUE, str)
+    assert isinstance(constants.RAW_FORMATS, set)
+    assert isinstance(constants.PHOTOBANK_SUPPORTED_FORMATS, dict)
+    assert isinstance(constants.FORMAT_SUBDIRS, dict)
+    assert isinstance(constants.PHOTOBANK_BATCH_SIZE_LIMITS, dict)
+
+
+def test_constants__jpg_supported_by_all_banks():
+    for bank, formats in constants.PHOTOBANK_SUPPORTED_FORMATS.items():
+        assert ".jpg" in formats, f"{bank} should support .jpg"
+
+
+def test_constants__format_subdirs_include_raw_formats():
+    for ext in constants.RAW_FORMATS:
+        assert constants.FORMAT_SUBDIRS.get(ext) == "raw"

--- a/createbatch/tests/unit/test_copy_media_items_to_batch__scenarios.py
+++ b/createbatch/tests/unit/test_copy_media_items_to_batch__scenarios.py
@@ -1,0 +1,127 @@
+"""
+Unit tests for copy_media_items_to_batch.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+createbatch_root = project_root / "createbatch"
+sys.path.insert(0, str(createbatch_root))
+
+from createbatchlib.copy_media_items_to_batch import copy_media_items_to_batch
+import createbatchlib.copy_media_items_to_batch as copy_module
+
+
+class DummyTqdm:
+    def __init__(self, total, desc, unit):
+        self.total = total
+        self.desc = desc
+        self.unit = unit
+        self.updates = 0
+
+    def update(self, count):
+        self.updates += count
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.fixture
+def patch_tqdm(monkeypatch):
+    monkeypatch.setattr(copy_module, "tqdm", DummyTqdm)
+
+
+def test_copy_media_items_to_batch__copies_and_updates_path(tmp_path, patch_tqdm):
+    source = tmp_path / "src.jpg"
+    source.write_text("data", encoding="utf-8")
+    dest_root = tmp_path / "out"
+    dest_root.mkdir()
+
+    items = [{"Cesta": str(source)}]
+    result = copy_media_items_to_batch(items, str(dest_root))
+
+    dest_path = dest_root / source.name
+    assert dest_path.exists()
+    assert result[0]["Cesta"] == str(dest_path)
+
+
+def test_copy_media_items_to_batch__skips_existing_destination(tmp_path, patch_tqdm):
+    source = tmp_path / "src.jpg"
+    source.write_text("source", encoding="utf-8")
+    dest_root = tmp_path / "out"
+    dest_root.mkdir()
+    dest_path = dest_root / source.name
+    dest_path.write_text("dest", encoding="utf-8")
+
+    items = [{"Cesta": str(source)}]
+    result = copy_media_items_to_batch(items, str(dest_root))
+
+    assert dest_path.read_text(encoding="utf-8") == "dest"
+    assert result[0]["Cesta"] == str(dest_path)
+
+
+def test_copy_media_items_to_batch__source_metadata_error_logs(tmp_path, patch_tqdm, monkeypatch, caplog):
+    source = tmp_path / "src.jpg"
+    source.write_text("data", encoding="utf-8")
+    dest_root = tmp_path / "out"
+    dest_root.mkdir()
+
+    original_stat = os.stat
+    calls = {"count": 0}
+
+    def flaky_stat(path):
+        if str(path) == str(source) and calls["count"] == 0:
+            calls["count"] += 1
+            raise OSError("stat failed")
+        return original_stat(path)
+
+    monkeypatch.setattr(copy_module.os, "stat", flaky_stat)
+
+    items = [{"Cesta": str(source)}]
+    with caplog.at_level("ERROR"):
+        copy_media_items_to_batch(items, str(dest_root))
+
+    assert "error retrieving source file metadata" in caplog.text.lower()
+
+
+def test_copy_media_items_to_batch__utime_error_logs(tmp_path, patch_tqdm, monkeypatch, caplog):
+    source = tmp_path / "src.jpg"
+    source.write_text("data", encoding="utf-8")
+    dest_root = tmp_path / "out"
+    dest_root.mkdir()
+
+    def fail_utime(_path, _times):
+        raise OSError("utime failed")
+
+    monkeypatch.setattr(copy_module.os, "utime", fail_utime)
+
+    items = [{"Cesta": str(source)}]
+    with caplog.at_level("ERROR"):
+        copy_media_items_to_batch(items, str(dest_root))
+
+    assert "error setting timestamps" in caplog.text.lower()
+
+
+def test_copy_media_items_to_batch__copy_failure_exits(tmp_path, patch_tqdm, monkeypatch):
+    source = tmp_path / "src.jpg"
+    source.write_text("data", encoding="utf-8")
+    dest_root = tmp_path / "out"
+    dest_root.mkdir()
+
+    def fail_copy(_src, _dst):
+        raise OSError("copy failed")
+
+    monkeypatch.setattr(copy_module.shutil, "copy2", fail_copy)
+
+    items = [{"Cesta": str(source)}]
+    with pytest.raises(SystemExit) as excinfo:
+        copy_media_items_to_batch(items, str(dest_root))
+
+    assert excinfo.value.code == 1

--- a/createbatch/tests/unit/test_createbatch__main__scenarios.py
+++ b/createbatch/tests/unit/test_createbatch__main__scenarios.py
@@ -1,0 +1,237 @@
+"""
+Unit tests for createbatch.py main flow and argument parsing.
+"""
+
+import logging
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+createbatch_root = project_root / "createbatch"
+sys.path.insert(0, str(project_root))
+sys.path.insert(0, str(createbatch_root))
+
+import createbatch as createbatch_module
+from createbatchlib import constants as cb_constants
+
+
+class DummyProcessor:
+    return_map = {}
+
+    def __init__(self, status_keyword, prepared_value):
+        self.status_keyword = status_keyword
+        self.prepared_value = prepared_value
+
+    def process_records_optimized(self, records, include_edited=False):
+        return DummyProcessor.return_map
+
+
+class DummyProgressTracker:
+    last_instance = None
+
+    def __init__(self, banks, records_per_bank):
+        self.banks = banks
+        self.records_per_bank = records_per_bank
+        self.started_banks = []
+        self.update_calls = []
+        self.finish_bank_calls = 0
+        self.finish_all_calls = 0
+        DummyProgressTracker.last_instance = self
+
+    def start_bank(self, bank):
+        self.started_banks.append(bank)
+
+    def update_progress(self, count):
+        self.update_calls.append(count)
+
+    def finish_bank(self):
+        self.finish_bank_calls += 1
+
+    def finish_all(self):
+        self.finish_all_calls += 1
+
+
+class TruthyEmptyMap:
+    def __len__(self):
+        return 1
+
+    def keys(self):
+        return []
+
+    def items(self):
+        return []
+
+
+def make_args(tmp_path, **overrides):
+    defaults = dict(
+        photo_csv=str(tmp_path / "input.csv"),
+        output_folder=str(tmp_path / "out"),
+        overwrite=False,
+        log_dir=str(tmp_path / "logs"),
+        debug=False,
+        include_edited=False,
+        include_alternative_formats=False,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+@pytest.fixture
+def common_patches(monkeypatch, tmp_path):
+    monkeypatch.setattr(createbatch_module, "ensure_directory", lambda _path: None)
+    monkeypatch.setattr(createbatch_module, "get_log_filename", lambda _log_dir: str(tmp_path / "log.txt"))
+    monkeypatch.setattr(createbatch_module, "setup_logging", lambda **_kwargs: None)
+    monkeypatch.setattr(createbatch_module, "ensure_exiftool", lambda: "exiftool")
+    monkeypatch.setattr(createbatch_module, "RecordProcessor", DummyProcessor)
+    monkeypatch.setattr(createbatch_module, "UnifiedProgressTracker", DummyProgressTracker)
+    return tmp_path
+
+
+def test_createbatch__parse_arguments__defaults(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["createbatch.py"])
+    args = createbatch_module.parse_arguments()
+
+    assert args.photo_csv == cb_constants.DEFAULT_PHOTO_CSV_FILE
+    assert args.output_folder == cb_constants.DEFAULT_PROCESSED_MEDIA_FOLDER
+    assert args.log_dir == cb_constants.DEFAULT_LOG_DIR
+    assert args.overwrite is False
+    assert args.debug is False
+    assert args.include_edited is False
+    assert args.include_alternative_formats is False
+
+
+def test_createbatch__parse_arguments__flags(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "createbatch.py",
+            "--photo_csv",
+            str(tmp_path / "photos.csv"),
+            "--output_folder",
+            str(tmp_path / "out"),
+            "--log_dir",
+            str(tmp_path / "logs"),
+            "--overwrite",
+            "--debug",
+            "--include-edited",
+            "--include-alternative-formats",
+        ],
+    )
+    args = createbatch_module.parse_arguments()
+
+    assert args.photo_csv.endswith("photos.csv")
+    assert args.output_folder.endswith("out")
+    assert args.log_dir.endswith("logs")
+    assert args.overwrite is True
+    assert args.debug is True
+    assert args.include_edited is True
+    assert args.include_alternative_formats is True
+
+
+def test_createbatch__main__no_prepared_records_exits(common_patches, monkeypatch, caplog):
+    DummyProcessor.return_map = {}
+    monkeypatch.setattr(createbatch_module, "parse_arguments", lambda: make_args(common_patches))
+    monkeypatch.setattr(createbatch_module, "load_csv", lambda _path: [])
+
+    with caplog.at_level(logging.WARNING):
+        createbatch_module.main()
+
+    assert "no prepared media records found" in caplog.text.lower()
+
+
+def test_createbatch__main__no_banks_exits(common_patches, monkeypatch, caplog):
+    DummyProcessor.return_map = TruthyEmptyMap()
+    monkeypatch.setattr(createbatch_module, "parse_arguments", lambda: make_args(common_patches))
+    monkeypatch.setattr(createbatch_module, "load_csv", lambda _path: [])
+
+    with caplog.at_level(logging.WARNING):
+        createbatch_module.main()
+
+    assert "no banks found in prepared records" in caplog.text.lower()
+
+
+def test_createbatch__main__batch_limit_uses_split(common_patches, monkeypatch):
+    records = [{"Cesta": "a.jpg"}, {"Cesta": "b.jpg"}]
+    DummyProcessor.return_map = {"Getty Images": records}
+
+    def split_batches(input_records, limit):
+        assert input_records == records
+        assert limit == 1
+        return [[records[0]], [records[1]]]
+
+    monkeypatch.setattr(createbatch_module, "parse_arguments", lambda: make_args(common_patches))
+    monkeypatch.setattr(createbatch_module, "load_csv", lambda _path: records)
+    monkeypatch.setattr(createbatch_module, "split_into_batches", split_batches)
+    monkeypatch.setattr(
+        createbatch_module,
+        "prepare_media_file",
+        lambda rec, *_args, **_kwargs: [rec["Cesta"]],
+    )
+    monkeypatch.setattr(createbatch_module, "PHOTOBANK_BATCH_SIZE_LIMITS", {"Getty Images": 1})
+
+    createbatch_module.main()
+
+    tracker = DummyProgressTracker.last_instance
+    assert tracker.started_banks == ["Getty Images"]
+    assert tracker.update_calls == [1, 1]
+    assert tracker.finish_all_calls == 1
+
+
+def test_createbatch__main__no_batch_limit_single_batch(common_patches, monkeypatch):
+    records = [{"Cesta": "a.jpg"}]
+    DummyProcessor.return_map = {"Adobe Stock": records}
+
+    def split_should_not_run(*_args, **_kwargs):
+        raise AssertionError("split_into_batches should not be called")
+
+    monkeypatch.setattr(createbatch_module, "parse_arguments", lambda: make_args(common_patches))
+    monkeypatch.setattr(createbatch_module, "load_csv", lambda _path: records)
+    monkeypatch.setattr(createbatch_module, "split_into_batches", split_should_not_run)
+    monkeypatch.setattr(
+        createbatch_module,
+        "prepare_media_file",
+        lambda rec, *_args, **_kwargs: [rec["Cesta"]],
+    )
+    monkeypatch.setattr(createbatch_module, "PHOTOBANK_BATCH_SIZE_LIMITS", {"Adobe Stock": 0})
+
+    createbatch_module.main()
+
+    tracker = DummyProgressTracker.last_instance
+    assert tracker.update_calls == [1]
+
+
+def test_createbatch__main__prepare_media_file_error_updates_progress(common_patches, monkeypatch, caplog):
+    records = [{"Cesta": "bad.jpg"}, {"Cesta": "good.jpg"}]
+    DummyProcessor.return_map = {"Shutterstock": records}
+
+    def prepare_media_file(rec, *_args, **_kwargs):
+        if rec["Cesta"] == "bad.jpg":
+            raise RuntimeError("boom")
+        return [rec["Cesta"]]
+
+    monkeypatch.setattr(createbatch_module, "parse_arguments", lambda: make_args(common_patches))
+    monkeypatch.setattr(createbatch_module, "load_csv", lambda _path: records)
+    monkeypatch.setattr(createbatch_module, "split_into_batches", lambda recs, _limit: [recs])
+    monkeypatch.setattr(createbatch_module, "prepare_media_file", prepare_media_file)
+    monkeypatch.setattr(createbatch_module, "PHOTOBANK_BATCH_SIZE_LIMITS", {"Shutterstock": 1})
+
+    with caplog.at_level(logging.ERROR):
+        createbatch_module.main()
+
+    tracker = DummyProgressTracker.last_instance
+    assert tracker.update_calls == [0, 1]
+    assert "error preparing file" in caplog.text.lower()
+
+
+def test_createbatch__main__zero_total_does_not_crash(common_patches, monkeypatch):
+    DummyProcessor.return_map = {"Alamy": []}
+    monkeypatch.setattr(createbatch_module, "parse_arguments", lambda: make_args(common_patches))
+    monkeypatch.setattr(createbatch_module, "load_csv", lambda _path: [])
+    monkeypatch.setattr(createbatch_module, "prepare_media_file", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(createbatch_module, "PHOTOBANK_BATCH_SIZE_LIMITS", {"Alamy": 0})
+
+    createbatch_module.main()

--- a/createbatch/tests/unit/test_createbatch_scripts__logging.py
+++ b/createbatch/tests/unit/test_createbatch_scripts__logging.py
@@ -1,0 +1,73 @@
+"""
+Unit tests for createbatch script logging setup.
+"""
+
+import importlib
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+createbatch_root = project_root / "createbatch"
+sys.path.insert(0, str(createbatch_root))
+
+
+class DummyHandler:
+    def __init__(self, *_args, **_kwargs):
+        self.level = None
+        self.formatter = None
+
+    def setLevel(self, level):
+        self.level = level
+
+    def setFormatter(self, formatter):
+        self.formatter = formatter
+
+
+class DummyLogger:
+    def __init__(self):
+        self.level = None
+        self.handlers = []
+
+    def setLevel(self, level):
+        self.level = level
+
+    def addHandler(self, handler):
+        self.handlers.append(handler)
+
+
+def import_with_dummy_colorlog(module_name):
+    class DummyColorlog:
+        StreamHandler = DummyHandler
+
+        class ColoredFormatter:
+            def __init__(self, *_args, **_kwargs):
+                return None
+
+    sys.modules["colorlog"] = DummyColorlog
+    sys.modules.pop(module_name, None)
+    return importlib.import_module(module_name)
+
+
+def assert_setup_logging(module_name):
+    module = import_with_dummy_colorlog(module_name)
+    dummy_logger = DummyLogger()
+
+    module.logging.getLogger = lambda: dummy_logger
+    module.logging.FileHandler = DummyHandler
+
+    logger = module.setup_logging()
+
+    assert logger is dummy_logger
+    assert len(dummy_logger.handlers) == 2
+
+
+def test_export_prepared_media_setup_logging():
+    assert_setup_logging("export_prepared_media")
+
+
+def test_launch_photobanks_setup_logging():
+    assert_setup_logging("launch_photobanks")
+
+
+def test_mark_media_as_checked_setup_logging():
+    assert_setup_logging("mark_media_as_checked")

--- a/createbatch/tests/unit/test_createbatch_shared_csv_sanitizer__scenarios.py
+++ b/createbatch/tests/unit/test_createbatch_shared_csv_sanitizer__scenarios.py
@@ -1,0 +1,53 @@
+"""
+Unit tests for createbatch/shared/csv_sanitizer.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+createbatch_root = project_root / "createbatch"
+sys.path.insert(0, str(createbatch_root))
+
+from shared.csv_sanitizer import sanitize_field, sanitize_record, sanitize_records, is_dangerous
+
+
+def test_sanitize_field__basic_cases():
+    assert sanitize_field("hello") == "hello"
+    assert sanitize_field("") == ""
+    assert sanitize_field(None) == ""
+    assert sanitize_field(123) == "123"
+
+
+def test_sanitize_field__dangerous_prefixes():
+    assert sanitize_field("=SUM(1,1)") == "'=SUM(1,1)"
+    assert sanitize_field("+SUM(1,1)") == "'+SUM(1,1)"
+    assert sanitize_field("-SUM(1,1)") == "'-SUM(1,1)"
+    assert sanitize_field("@SUM(1,1)") == "'@SUM(1,1)"
+
+
+def test_sanitize_field__suspicious_patterns():
+    assert sanitize_field("cmd|calc") == "'cmd|calc"
+    assert sanitize_field("file:///etc/passwd") == "'file:///etc/passwd"
+    assert sanitize_field(r"\\server\share") == "'\\server\\share"
+
+
+def test_sanitize_field__leading_quote_normalized():
+    assert sanitize_field("'=SUM(1,1)") == "'=SUM(1,1)"
+
+
+def test_sanitize_record_and_records():
+    record = {"a": "=1+1", "b": "safe"}
+    sanitized = sanitize_record(record)
+    assert sanitized["a"].startswith("'")
+    assert sanitized["b"] == "safe"
+
+    records = [record, {"a": "ok"}]
+    sanitized_records = sanitize_records(records)
+    assert len(sanitized_records) == 2
+
+
+def test_is_dangerous():
+    assert is_dangerous("=SUM(1,1)") is True
+    assert is_dangerous("normal") is False
+    assert is_dangerous("") is False

--- a/createbatch/tests/unit/test_createbatch_shared_exif_downloader__scenarios.py
+++ b/createbatch/tests/unit/test_createbatch_shared_exif_downloader__scenarios.py
@@ -1,0 +1,29 @@
+"""
+Unit tests for createbatch/shared/exif_downloader.py.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+createbatch_root = project_root / "createbatch"
+sys.path.insert(0, str(createbatch_root))
+
+import shared.exif_downloader as exif_downloader
+
+
+def test_ensure_exiftool__returns_path_when_exists(monkeypatch):
+    monkeypatch.setattr(exif_downloader, "EXIFTOOL_PATH", "C:/Tools/exiftool.exe")
+    monkeypatch.setattr(exif_downloader.os.path, "exists", lambda _p: True)
+
+    assert exif_downloader.ensure_exiftool() == "C:/Tools/exiftool.exe"
+
+
+def test_ensure_exiftool__raises_when_missing(monkeypatch):
+    monkeypatch.setattr(exif_downloader, "EXIFTOOL_PATH", "C:/Tools/exiftool.exe")
+    monkeypatch.setattr(exif_downloader.os.path, "exists", lambda _p: False)
+
+    with pytest.raises(FileNotFoundError):
+        exif_downloader.ensure_exiftool()

--- a/createbatch/tests/unit/test_createbatch_shared_exif_handler__scenarios.py
+++ b/createbatch/tests/unit/test_createbatch_shared_exif_handler__scenarios.py
@@ -1,0 +1,134 @@
+"""
+Unit tests for createbatch/shared/exif_handler.py.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+createbatch_root = project_root / "createbatch"
+sys.path.insert(0, str(createbatch_root))
+
+import shared.exif_handler as exif_handler
+
+
+def test_update_exif_metadata__uses_tool_path_directory(monkeypatch, tmp_path):
+    exe = tmp_path / "exiftool.exe"
+    exe.write_text("bin", encoding="utf-8")
+
+    monkeypatch.setattr(exif_handler.os, "name", "nt")
+    monkeypatch.setattr(exif_handler.os.path, "isdir", lambda p: True)
+    monkeypatch.setattr(exif_handler.os.path, "isfile", lambda p: True)
+    monkeypatch.setattr(exif_handler.os, "access", lambda p, mode: True)
+    monkeypatch.setattr(exif_handler, "shutil", exif_handler.shutil)
+
+    run_args = {}
+
+    def fake_run(args, capture_output, text, check):
+        run_args["args"] = args
+        return type("Result", (), {"stdout": "ok"})
+
+    monkeypatch.setattr(exif_handler.subprocess, "run", fake_run)
+
+    exif_handler.update_exif_metadata(
+        "C:/media/file.jpg",
+        {"title": "t"},
+        tool_path=str(tmp_path),
+    )
+
+    assert run_args["args"][0].endswith("exiftool.exe")
+
+
+def test_update_exif_metadata__uses_tool_path_file(monkeypatch):
+    monkeypatch.setattr(exif_handler.os.path, "isdir", lambda p: False)
+    monkeypatch.setattr(exif_handler.os.path, "isfile", lambda p: True)
+    monkeypatch.setattr(exif_handler.os, "access", lambda p, mode: True)
+    monkeypatch.setattr(exif_handler.shutil, "which", lambda _n: None)
+
+    run_args = {}
+
+    def fake_run(args, capture_output, text, check):
+        run_args["args"] = args
+        return type("Result", (), {"stdout": "ok"})
+
+    monkeypatch.setattr(exif_handler.subprocess, "run", fake_run)
+
+    exif_handler.update_exif_metadata("C:/media/file.jpg", {}, tool_path="C:/tools/exiftool.exe")
+
+    assert run_args["args"][0] == "C:/tools/exiftool.exe"
+
+
+def test_update_exif_metadata__falls_back_to_path(monkeypatch):
+    monkeypatch.setattr(exif_handler.os.path, "isdir", lambda p: False)
+    monkeypatch.setattr(exif_handler.os.path, "isfile", lambda p: False)
+    monkeypatch.setattr(exif_handler.os, "access", lambda p, mode: False)
+    monkeypatch.setattr(exif_handler.shutil, "which", lambda _n: "C:/bin/exiftool.exe")
+
+    run_args = {}
+
+    def fake_run(args, capture_output, text, check):
+        run_args["args"] = args
+        return type("Result", (), {"stdout": "ok"})
+
+    monkeypatch.setattr(exif_handler.subprocess, "run", fake_run)
+
+    exif_handler.update_exif_metadata("C:/media/file.jpg", {}, tool_path=None)
+
+    assert run_args["args"][0] == "C:/bin/exiftool.exe"
+
+
+def test_update_exif_metadata__raises_when_missing(monkeypatch):
+    monkeypatch.setattr(exif_handler.os.path, "isdir", lambda p: False)
+    monkeypatch.setattr(exif_handler.os.path, "isfile", lambda p: False)
+    monkeypatch.setattr(exif_handler.os, "access", lambda p, mode: False)
+    monkeypatch.setattr(exif_handler.shutil, "which", lambda _n: None)
+
+    with pytest.raises(RuntimeError):
+        exif_handler.update_exif_metadata("C:/media/file.jpg", {}, tool_path=None)
+
+
+def test_update_exif_metadata__passes_metadata(monkeypatch):
+    monkeypatch.setattr(exif_handler.os.path, "isdir", lambda p: False)
+    monkeypatch.setattr(exif_handler.os.path, "isfile", lambda p: True)
+    monkeypatch.setattr(exif_handler.os, "access", lambda p, mode: True)
+
+    captured = {}
+
+    def fake_run(args, capture_output, text, check):
+        captured["args"] = args
+        return type("Result", (), {"stdout": "ok"})
+
+    monkeypatch.setattr(exif_handler.subprocess, "run", fake_run)
+
+    exif_handler.update_exif_metadata(
+        "C:/media/file.jpg",
+        {
+            "title": "Title",
+            "description": "Desc",
+            "keywords": "a,b",
+            "datetimeoriginal": "2020:01:01 00:00:00",
+        },
+        tool_path="C:/tools/exiftool.exe",
+    )
+
+    args_str = " ".join(captured["args"])
+    assert "-Title=Title" in args_str
+    assert "-Description=Desc" in args_str
+    assert "-Keywords=a,b" in args_str
+    assert "-DateTimeOriginal=2020:01:01 00:00:00" in args_str
+
+
+def test_update_exif_metadata__subprocess_error_raised(monkeypatch):
+    monkeypatch.setattr(exif_handler.os.path, "isdir", lambda p: False)
+    monkeypatch.setattr(exif_handler.os.path, "isfile", lambda p: True)
+    monkeypatch.setattr(exif_handler.os, "access", lambda p, mode: True)
+
+    def fake_run(*_args, **_kwargs):
+        raise exif_handler.subprocess.CalledProcessError(1, "exiftool", stderr="fail")
+
+    monkeypatch.setattr(exif_handler.subprocess, "run", fake_run)
+
+    with pytest.raises(exif_handler.subprocess.CalledProcessError):
+        exif_handler.update_exif_metadata("C:/media/file.jpg", {}, tool_path="C:/tools/exiftool.exe")

--- a/createbatch/tests/unit/test_createbatch_shared_file_operations__scenarios.py
+++ b/createbatch/tests/unit/test_createbatch_shared_file_operations__scenarios.py
@@ -1,0 +1,123 @@
+"""
+Unit tests for createbatch/shared/file_operations.py.
+"""
+
+import csv
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+createbatch_root = project_root / "createbatch"
+sys.path.insert(0, str(createbatch_root))
+
+import shared.file_operations as file_ops
+
+
+class DummyTqdm:
+    def __init__(self, iterable=None, total=None, desc=None, unit=None):
+        self.iterable = iterable
+
+    def __iter__(self):
+        return iter(self.iterable or [])
+
+
+@pytest.fixture
+def patch_tqdm(monkeypatch):
+    monkeypatch.setattr(file_ops, "tqdm", DummyTqdm)
+
+
+def test_copy_file__skips_when_overwrite_false(tmp_path):
+    source = tmp_path / "src.txt"
+    dest = tmp_path / "dest.txt"
+    source.write_text("src", encoding="utf-8")
+    dest.write_text("dest", encoding="utf-8")
+
+    file_ops.copy_file(str(source), str(dest), overwrite=False)
+
+    assert dest.read_text(encoding="utf-8") == "dest"
+
+
+def test_copy_file__creates_destination_dir(tmp_path):
+    source = tmp_path / "src.txt"
+    source.write_text("src", encoding="utf-8")
+    dest = tmp_path / "nested" / "dest.txt"
+
+    file_ops.copy_file(str(source), str(dest), overwrite=True)
+
+    assert dest.exists()
+
+
+def test_copy_file__raises_on_error(monkeypatch):
+    monkeypatch.setattr(file_ops.shutil, "copy2", lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("fail")))
+
+    with pytest.raises(OSError):
+        file_ops.copy_file("missing", "dest")
+
+
+def test_ensure_directory__creates(tmp_path):
+    target = tmp_path / "newdir"
+    file_ops.ensure_directory(str(target))
+    assert target.exists()
+
+
+def test_ensure_directory__raises(monkeypatch):
+    monkeypatch.setattr(file_ops.os, "makedirs", lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("fail")))
+    with pytest.raises(OSError):
+        file_ops.ensure_directory("C:/bad/path")
+
+
+def test_load_csv__header_only_returns_empty(tmp_path, patch_tqdm):
+    csv_path = tmp_path / "data.csv"
+    csv_path.write_text("A,B\n", encoding="utf-8")
+
+    records = file_ops.load_csv(str(csv_path))
+
+    assert records == []
+
+
+def test_load_csv__missing_raises(patch_tqdm):
+    with pytest.raises(Exception):
+        file_ops.load_csv("Z:/missing.csv")
+
+
+def test_save_csv__sanitizes_when_enabled(tmp_path, patch_tqdm, monkeypatch):
+    records = [{"A": "=1+1", "B": "ok"}]
+    output = tmp_path / "out.csv"
+
+    called = {}
+
+    def fake_sanitize(recs):
+        called["recs"] = recs
+        return [{"A": "'=1+1", "B": "ok"}]
+
+    monkeypatch.setattr(file_ops, "sanitize_records", fake_sanitize)
+
+    file_ops.save_csv(records, str(output), sanitize=True)
+
+    content = output.read_text(encoding="utf-8-sig")
+    assert "'=1+1" in content
+    assert "A" in content
+    assert called["recs"] == records
+
+
+def test_save_csv__raw_when_sanitize_false(tmp_path, patch_tqdm):
+    records = [{"A": "=1+1", "B": "ok"}]
+    output = tmp_path / "out.csv"
+
+    file_ops.save_csv(records, str(output), sanitize=False)
+
+    content = output.read_text(encoding="utf-8-sig")
+    assert "=1+1" in content
+
+
+def test_save_csv__empty_records_warns(tmp_path, patch_tqdm, caplog):
+    output = tmp_path / "out.csv"
+
+    with caplog.at_level("WARNING"):
+        file_ops.save_csv([], str(output), sanitize=True)
+
+    assert not output.exists()
+    assert "no records to save" in caplog.text.lower()

--- a/createbatch/tests/unit/test_createbatch_shared_logging_config__scenarios.py
+++ b/createbatch/tests/unit/test_createbatch_shared_logging_config__scenarios.py
@@ -1,0 +1,89 @@
+"""
+Unit tests for createbatch/shared/logging_config.py.
+"""
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+createbatch_root = project_root / "createbatch"
+sys.path.insert(0, str(createbatch_root))
+
+import shared.logging_config as logging_config
+
+
+class DummyHandler:
+    def __init__(self, *_args, **_kwargs):
+        self.formatter = None
+
+    def setFormatter(self, formatter):
+        self.formatter = formatter
+
+
+class DummyLogger:
+    def __init__(self):
+        self.handlers = [DummyHandler()]
+        self.level = None
+
+    def setLevel(self, level):
+        self.level = level
+
+    def addHandler(self, handler):
+        self.handlers.append(handler)
+
+    def removeHandler(self, handler):
+        self.handlers.remove(handler)
+
+
+class DummyFormatter:
+    def __init__(self, *_args, **_kwargs):
+        return None
+
+
+def test_setup_logging__missing_config_raises(monkeypatch):
+    def fail_open(*_args, **_kwargs):
+        raise OSError("missing")
+
+    monkeypatch.setattr(logging_config, "open", fail_open)
+
+    with pytest.raises(Exception):
+        logging_config.setup_logging()
+
+
+def test_setup_logging__sets_level_and_handlers(monkeypatch):
+    dummy_logger = DummyLogger()
+
+    monkeypatch.setattr(logging_config.logging, "getLogger", lambda: dummy_logger)
+    monkeypatch.setattr(logging_config.logging, "StreamHandler", DummyHandler)
+    monkeypatch.setattr(logging_config.logging, "FileHandler", DummyHandler)
+    monkeypatch.setattr(logging_config.colorlog, "ColoredFormatter", DummyFormatter)
+
+    def fake_open(*_args, **_kwargs):
+        class DummyFile:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return '{"DEBUG": "white", "INFO": "green", "WARNING": "yellow", "ERROR": "red", "CRITICAL": "red"}'
+
+        return DummyFile()
+
+    monkeypatch.setattr(logging_config, "open", fake_open)
+    monkeypatch.setattr(logging_config.json, "load", lambda _f: {
+        "DEBUG": "white",
+        "INFO": "green",
+        "WARNING": "yellow",
+        "ERROR": "red",
+        "CRITICAL": "red",
+    })
+
+    logging_config.setup_logging(debug=True, log_file="C:/logs/test.log")
+
+    assert dummy_logger.level == logging_config.logging.DEBUG
+    assert len(dummy_logger.handlers) == 2

--- a/createbatch/tests/unit/test_createbatch_shared_utils__scenarios.py
+++ b/createbatch/tests/unit/test_createbatch_shared_utils__scenarios.py
@@ -1,0 +1,37 @@
+"""
+Unit tests for createbatch/shared/utils.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+createbatch_root = project_root / "createbatch"
+sys.path.insert(0, str(createbatch_root))
+
+import shared.utils as utils
+
+
+def test_get_script_name__uses_argv_basename(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["C:/scripts/run_me.py"])
+
+    assert utils.get_script_name() == "run_me"
+
+
+def test_get_log_filename__includes_script_name_and_timestamp(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["C:/scripts/run_me.py"])
+
+    class DummyDateTime:
+        @classmethod
+        def now(cls):
+            class Dummy:
+                def strftime(self, _fmt):
+                    return "2020-01-01_12-00-00"
+
+            return Dummy()
+
+    monkeypatch.setattr(utils, "datetime", DummyDateTime)
+
+    result = utils.get_log_filename("C:/logs")
+
+    assert result.endswith("run_me_Log_2020-01-01_12-00-00.log")

--- a/createbatch/tests/unit/test_ensure_directories__scenarios.py
+++ b/createbatch/tests/unit/test_ensure_directories__scenarios.py
@@ -1,0 +1,73 @@
+"""
+Unit tests for ensure_directories.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+createbatch_root = project_root / "createbatch"
+sys.path.insert(0, str(createbatch_root))
+
+from createbatchlib.ensure_directories import ensure_directories
+import createbatchlib.ensure_directories as ensure_module
+
+
+class DummyTqdm:
+    def __init__(self, total, desc, unit):
+        self.total = total
+        self.desc = desc
+        self.unit = unit
+
+    def update(self, _count):
+        return None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.fixture
+def patch_tqdm(monkeypatch):
+    monkeypatch.setattr(ensure_module, "tqdm", DummyTqdm)
+
+
+def test_ensure_directories__creates_missing_dirs(tmp_path, patch_tqdm):
+    out_dir = tmp_path / "out"
+    log_dir = tmp_path / "logs"
+
+    ensure_directories(str(out_dir), str(log_dir))
+
+    assert out_dir.exists()
+    assert log_dir.exists()
+
+
+def test_ensure_directories__existing_dirs_ok(tmp_path, patch_tqdm):
+    out_dir = tmp_path / "out"
+    log_dir = tmp_path / "logs"
+    out_dir.mkdir()
+    log_dir.mkdir()
+
+    ensure_directories(str(out_dir), str(log_dir))
+
+    assert out_dir.exists()
+    assert log_dir.exists()
+
+
+def test_ensure_directories__error_exits(tmp_path, patch_tqdm, monkeypatch):
+    out_dir = tmp_path / "out"
+    log_dir = tmp_path / "logs"
+
+    def fail_makedirs(_path):
+        raise OSError("no permission")
+
+    monkeypatch.setattr(ensure_module.os, "makedirs", fail_makedirs)
+
+    with pytest.raises(SystemExit) as excinfo:
+        ensure_directories(str(out_dir), str(log_dir))
+
+    assert excinfo.value.code == 1

--- a/createbatch/tests/unit/test_extensions__illustration.py
+++ b/createbatch/tests/unit/test_extensions__illustration.py
@@ -1,0 +1,18 @@
+"""
+Unit tests for illustration extensions list.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+createbatch_root = project_root / "createbatch"
+sys.path.insert(0, str(createbatch_root))
+
+from createbatchlib.illustration_extensions import ILLUSTRATION_EXTENSIONS
+
+
+def test_illustration_extensions__expected_values():
+    assert isinstance(ILLUSTRATION_EXTENSIONS, list)
+    assert "ai" in ILLUSTRATION_EXTENSIONS
+    assert "svg" in ILLUSTRATION_EXTENSIONS

--- a/createbatch/tests/unit/test_extensions__image.py
+++ b/createbatch/tests/unit/test_extensions__image.py
@@ -1,0 +1,18 @@
+"""
+Unit tests for image extensions list.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+createbatch_root = project_root / "createbatch"
+sys.path.insert(0, str(createbatch_root))
+
+from createbatchlib.image_extensions import IMAGE_EXTENSIONS
+
+
+def test_image_extensions__expected_values():
+    assert isinstance(IMAGE_EXTENSIONS, list)
+    for ext in ["jpg", "jpeg", "png", "tiff", "tif", "raw", "nef", "dng"]:
+        assert ext in IMAGE_EXTENSIONS

--- a/createbatch/tests/unit/test_extensions__video.py
+++ b/createbatch/tests/unit/test_extensions__video.py
@@ -1,0 +1,18 @@
+"""
+Unit tests for video extensions list.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+createbatch_root = project_root / "createbatch"
+sys.path.insert(0, str(createbatch_root))
+
+from createbatchlib.video_extensions import VIDEO_EXTENSIONS
+
+
+def test_video_extensions__expected_values():
+    assert isinstance(VIDEO_EXTENSIONS, list)
+    for ext in ["mp4", "mov", "avi", "mkv", "webm"]:
+        assert ext in VIDEO_EXTENSIONS

--- a/createbatch/tests/unit/test_filtering__scenarios.py
+++ b/createbatch/tests/unit/test_filtering__scenarios.py
@@ -1,0 +1,69 @@
+"""
+Unit tests for filter_prepared_media.
+"""
+
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+createbatch_root = project_root / "createbatch"
+sys.path.insert(0, str(createbatch_root))
+
+from createbatchlib import constants
+from createbatchlib.filtering import filter_prepared_media
+
+
+def test_filter_prepared_media__filters_by_prepared_status():
+    records = [
+        {"Cesta": "C:/Photos/a.jpg", "Shutterstock Status": constants.PREPARED_STATUS_VALUE},
+        {"Cesta": "C:/Photos/b.jpg", "Adobe Stock Status": "ne" + constants.PREPARED_STATUS_VALUE},
+    ]
+
+    result = filter_prepared_media(records, include_edited=False)
+
+    assert result == [records[0]]
+
+
+def test_filter_prepared_media__case_insensitive_status_key_and_value():
+    records = [
+        {"Cesta": "C:/Photos/a.jpg", "Shutterstock STATUS": constants.PREPARED_STATUS_VALUE.upper()},
+    ]
+
+    result = filter_prepared_media(records, include_edited=False)
+
+    assert result == records
+
+
+def test_filter_prepared_media__excludes_edited_when_disabled():
+    records = [
+        {"Cesta": "C:/Photos/upraven‚/a.jpg", "Shutterstock Status": constants.PREPARED_STATUS_VALUE},
+        {"Cesta": "C:/Photos/original/b.jpg", "Shutterstock Status": constants.PREPARED_STATUS_VALUE},
+    ]
+
+    result = filter_prepared_media(records, include_edited=False)
+
+    assert result == [records[1]]
+
+
+def test_filter_prepared_media__includes_edited_when_enabled():
+    records = [
+        {"Cesta": "C:/Photos/upraven‚/a.jpg", "Shutterstock Status": constants.PREPARED_STATUS_VALUE},
+    ]
+
+    result = filter_prepared_media(records, include_edited=True)
+
+    assert result == records
+
+
+def test_filter_prepared_media__logs_summary(caplog):
+    records = [
+        {"Cesta": "C:/Photos/upraven‚/a.jpg", "Shutterstock Status": constants.PREPARED_STATUS_VALUE},
+    ]
+
+    with caplog.at_level(logging.INFO):
+        filter_prepared_media(records, include_edited=False)
+
+    assert "filtered" in caplog.text.lower()

--- a/createbatch/tests/unit/test_get_prepared_media_items__scenarios.py
+++ b/createbatch/tests/unit/test_get_prepared_media_items__scenarios.py
@@ -1,0 +1,74 @@
+"""
+Unit tests for get_prepared_media_items.
+"""
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+createbatch_root = project_root / "createbatch"
+sys.path.insert(0, str(createbatch_root))
+
+import createbatchlib.constants as constants
+
+
+class DummyTqdm:
+    def __init__(self, total, desc, unit):
+        self.total = total
+        self.desc = desc
+        self.unit = unit
+
+    def update(self, _count):
+        return None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def import_module_fresh():
+    sys.modules.pop("createbatchlib.get_prepared_media_items", None)
+    return importlib.import_module("createbatchlib.get_prepared_media_items")
+
+
+def test_get_prepared_media_items__missing_constant_import_error():
+    if hasattr(constants, "PREPARED_STATUS"):
+        delattr(constants, "PREPARED_STATUS")
+
+    sys.modules.pop("createbatchlib.get_prepared_media_items", None)
+
+    with pytest.raises(ImportError):
+        importlib.import_module("createbatchlib.get_prepared_media_items")
+
+
+def test_get_prepared_media_items__filters_prepared(monkeypatch):
+    constants.PREPARED_STATUS = constants.PREPARED_STATUS_VALUE
+    module = import_module_fresh()
+    monkeypatch.setattr(module, "tqdm", DummyTqdm)
+
+    items = [
+        {"Cesta": "a.jpg", "Shutterstock Status": constants.PREPARED_STATUS},
+        {"Cesta": "b.jpg", "Shutterstock Status": "ne" + constants.PREPARED_STATUS},
+    ]
+
+    result = module.get_prepared_media_items(items)
+
+    assert result == [items[0]]
+
+
+def test_get_prepared_media_items__value_error_exits(monkeypatch):
+    constants.PREPARED_STATUS = constants.PREPARED_STATUS_VALUE
+    module = import_module_fresh()
+    monkeypatch.setattr(module, "tqdm", DummyTqdm)
+
+    items = [{"Cesta": "a.jpg", "Shutterstock Status": None}]
+
+    with pytest.raises(SystemExit) as excinfo:
+        module.get_prepared_media_items(items)
+
+    assert excinfo.value.code == 1

--- a/createbatch/tests/unit/test_load_csv__scenarios.py
+++ b/createbatch/tests/unit/test_load_csv__scenarios.py
@@ -1,0 +1,53 @@
+"""
+Unit tests for load_csv.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+createbatch_root = project_root / "createbatch"
+sys.path.insert(0, str(createbatch_root))
+
+from createbatchlib.load_csv import load_csv
+import createbatchlib.load_csv as load_module
+
+
+class DummyTqdm:
+    def __init__(self, total, desc, unit):
+        self.total = total
+        self.desc = desc
+        self.unit = unit
+        self.updates = 0
+
+    def update(self, count):
+        self.updates += count
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.fixture
+def patch_tqdm(monkeypatch):
+    monkeypatch.setattr(load_module, "tqdm", DummyTqdm)
+
+
+def test_load_csv__returns_rows_as_dicts(tmp_path, patch_tqdm):
+    csv_path = tmp_path / "input.csv"
+    csv_path.write_text("A,B\n1,alpha\n2,beta\n", encoding="utf-8")
+
+    items = load_csv(str(csv_path))
+
+    assert items == [{"A": 1, "B": "alpha"}, {"A": 2, "B": "beta"}]
+
+
+def test_load_csv__missing_file_exits(patch_tqdm):
+    with pytest.raises(SystemExit) as excinfo:
+        load_csv("Z:/missing/file.csv")
+
+    assert excinfo.value.code == 1

--- a/createbatch/tests/unit/test_media_preparation__find_files_to_copy__scenarios.py
+++ b/createbatch/tests/unit/test_media_preparation__find_files_to_copy__scenarios.py
@@ -1,0 +1,58 @@
+"""
+Unit tests for _find_files_to_copy.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+createbatch_root = project_root / "createbatch"
+sys.path.insert(0, str(project_root))
+sys.path.insert(0, str(createbatch_root))
+
+from createbatchlib.media_preparation import _find_files_to_copy
+
+
+def test_find_files_to_copy__returns_source_when_supported(tmp_path):
+    source = tmp_path / "JPG" / "set" / "image.jpg"
+    source.parent.mkdir(parents=True)
+    source.write_text("x", encoding="utf-8")
+
+    result = _find_files_to_copy(str(source), include_alternatives=False, supported_formats={".jpg"})
+
+    assert result == [str(source)]
+
+
+def test_find_files_to_copy__includes_alternatives_when_present(tmp_path):
+    source = tmp_path / "JPG" / "set" / "image.jpg"
+    alternative = tmp_path / "PNG" / "set" / "image.png"
+    source.parent.mkdir(parents=True)
+    alternative.parent.mkdir(parents=True)
+    source.write_text("x", encoding="utf-8")
+    alternative.write_text("y", encoding="utf-8")
+
+    result = _find_files_to_copy(
+        str(source),
+        include_alternatives=True,
+        supported_formats={".jpg", ".png"},
+    )
+
+    assert set(result) == {str(source), str(alternative)}
+
+
+def test_find_files_to_copy__warns_when_format_dir_missing(tmp_path, caplog):
+    source = tmp_path / "set" / "image.jpg"
+    source.parent.mkdir(parents=True)
+    source.write_text("x", encoding="utf-8")
+
+    with caplog.at_level("WARNING"):
+        result = _find_files_to_copy(
+            str(source),
+            include_alternatives=True,
+            supported_formats={".jpg", ".png"},
+        )
+
+    assert result == [str(source)]
+    assert "could not identify format directory" in caplog.text.lower()

--- a/createbatch/tests/unit/test_media_preparation__prepare_media_file__scenarios.py
+++ b/createbatch/tests/unit/test_media_preparation__prepare_media_file__scenarios.py
@@ -1,0 +1,136 @@
+"""
+Unit tests for prepare_media_file.
+"""
+
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+createbatch_root = project_root / "createbatch"
+sys.path.insert(0, str(project_root))
+sys.path.insert(0, str(createbatch_root))
+
+import createbatchlib.media_preparation as media_module
+from createbatchlib import constants
+
+
+@pytest.fixture
+def patched_dependencies(monkeypatch):
+    ensure_calls = []
+    copy_calls = []
+    exif_calls = []
+
+    monkeypatch.setattr(media_module, "ensure_directory", lambda path: ensure_calls.append(path))
+
+    def fake_copy(src, dest, overwrite=True):
+        copy_calls.append((src, dest, overwrite))
+
+    def fake_update(dest, metadata, exif_tool_path):
+        exif_calls.append((dest, metadata, exif_tool_path))
+
+    monkeypatch.setattr(media_module, "copy_file", fake_copy)
+    monkeypatch.setattr(media_module, "update_exif_metadata", fake_update)
+    monkeypatch.setattr(media_module, "sanitize_field", lambda value: value)
+
+    return ensure_calls, copy_calls, exif_calls
+
+
+def test_prepare_media_file__missing_source_logs_and_returns_empty(tmp_path, caplog, patched_dependencies):
+    record = {"Cesta": str(tmp_path / "missing.jpg"), "Shutterstock Status": constants.PREPARED_STATUS_VALUE}
+
+    with caplog.at_level(logging.WARNING):
+        result = media_module.prepare_media_file(
+            record,
+            output_folder=str(tmp_path / "out"),
+            exif_tool_path="exiftool",
+        )
+
+    assert result == []
+    assert "source file does not exist" in caplog.text.lower()
+
+
+def test_prepare_media_file__copies_to_expected_folder(tmp_path, patched_dependencies):
+    ensure_calls, copy_calls, exif_calls = patched_dependencies
+    source = tmp_path / "image_bw.jpg"
+    source.write_text("data", encoding="utf-8")
+
+    record = {"Cesta": str(source), "Shutterstock Status": constants.PREPARED_STATUS_VALUE}
+
+    result = media_module.prepare_media_file(
+        record,
+        output_folder=str(tmp_path / "out"),
+        exif_tool_path="exiftool",
+        overwrite=False,
+        bank="Shutterstock",
+        include_alternative_formats=False,
+    )
+
+    expected_dir = tmp_path / "out" / "Shutterstock" / "jpg" / "_bw"
+    expected_dest = expected_dir / source.name
+
+    assert ensure_calls == [str(expected_dir)]
+    assert copy_calls == [(str(source), str(expected_dest), False)]
+    assert exif_calls and exif_calls[0][0] == str(expected_dest)
+    assert result == [str(expected_dest)]
+
+
+def test_prepare_media_file__bank_mismatch_skips(tmp_path, patched_dependencies):
+    source = tmp_path / "image.jpg"
+    source.write_text("data", encoding="utf-8")
+    record = {"Cesta": str(source), "Shutterstock Status": constants.PREPARED_STATUS_VALUE}
+
+    result = media_module.prepare_media_file(
+        record,
+        output_folder=str(tmp_path / "out"),
+        exif_tool_path="exiftool",
+        bank="Adobe Stock",
+    )
+
+    assert result == []
+
+
+def test_prepare_media_file__uses_batch_folder(tmp_path, patched_dependencies):
+    ensure_calls, copy_calls, _exif_calls = patched_dependencies
+    source = tmp_path / "image.jpg"
+    source.write_text("data", encoding="utf-8")
+    record = {"Cesta": str(source), "Shutterstock Status": constants.PREPARED_STATUS_VALUE}
+
+    result = media_module.prepare_media_file(
+        record,
+        output_folder=str(tmp_path / "out"),
+        exif_tool_path="exiftool",
+        bank="Shutterstock",
+        batch_number=2,
+    )
+
+    expected_dir = tmp_path / "out" / "Shutterstock" / "batch_002" / "jpg" / "original"
+    expected_dest = expected_dir / source.name
+
+    assert ensure_calls == [str(expected_dir)]
+    assert copy_calls[0][1] == str(expected_dest)
+    assert result == [str(expected_dest)]
+
+
+def test_prepare_media_file__copy_error_logs_and_continues(tmp_path, patched_dependencies, monkeypatch, caplog):
+    source = tmp_path / "image.jpg"
+    source.write_text("data", encoding="utf-8")
+    record = {"Cesta": str(source), "Shutterstock Status": constants.PREPARED_STATUS_VALUE}
+
+    def fail_copy(_src, _dest, overwrite=True):
+        raise OSError("copy failed")
+
+    monkeypatch.setattr(media_module, "copy_file", fail_copy)
+
+    with caplog.at_level(logging.ERROR):
+        result = media_module.prepare_media_file(
+            record,
+            output_folder=str(tmp_path / "out"),
+            exif_tool_path="exiftool",
+            bank="Shutterstock",
+        )
+
+    assert result == []
+    assert "failed to copy" in caplog.text.lower()

--- a/createbatch/tests/unit/test_media_preparation__split_into_batches__edge_cases.py
+++ b/createbatch/tests/unit/test_media_preparation__split_into_batches__edge_cases.py
@@ -1,0 +1,290 @@
+"""
+Unit tests for split_into_batches() function - Edge Cases
+
+Tests the batch splitting logic with all edge cases including:
+- Empty records
+- Single record
+- Below/at/above batch size limit
+- Multiple batches
+- Invalid batch sizes
+- Large datasets
+- Warning log verification
+
+Author: Unit Test Specialist
+Created: 2026-01-04
+Related: PR #120 (Getty Images batch size 128 limit)
+"""
+
+import pytest
+import logging
+from typing import List, Dict
+from createbatchlib.media_preparation import split_into_batches
+
+
+# Fixtures
+
+@pytest.fixture
+def sample_record() -> Dict[str, str]:
+    """Single sample record for testing."""
+    return {
+        "Cesta": "J:/Foto/JPG/Nature/2024/01/Camera/DSC00001.jpg",
+        "Název": "Beautiful sunset",
+        "Popis": "Sunset over mountains",
+        "Klíčová slova": "sunset, nature, mountains"
+    }
+
+
+@pytest.fixture
+def create_records(sample_record):
+    """Factory fixture to create N records."""
+    def _create(count: int) -> List[Dict[str, str]]:
+        """Create count records with unique filenames."""
+        return [
+            {**sample_record, "Cesta": f"DSC{i:05d}.jpg"}
+            for i in range(count)
+        ]
+    return _create
+
+
+# Edge Case Tests
+
+@pytest.mark.timeout(10)
+def test_media_preparation__split_into_batches__empty_records_returns_empty_list():
+    """Test that empty records list returns empty list."""
+    result = split_into_batches([], batch_size=128)
+
+    assert result == [], "Empty records should return empty list"
+    assert isinstance(result, list), "Return type should be list"
+
+
+@pytest.mark.timeout(10)
+def test_media_preparation__split_into_batches__single_record_returns_single_batch(sample_record):
+    """Test that single record returns one batch with one item."""
+    records = [sample_record]
+    result = split_into_batches(records, batch_size=128)
+
+    assert len(result) == 1, "Should return 1 batch"
+    assert len(result[0]) == 1, "Batch should contain 1 item"
+    assert result[0][0] == sample_record, "Item should match original"
+
+
+@pytest.mark.timeout(10)
+def test_media_preparation__split_into_batches__below_limit_returns_single_batch(create_records):
+    """Test that 127 items with batch_size=128 returns single batch."""
+    records = create_records(127)
+    result = split_into_batches(records, batch_size=128)
+
+    assert len(result) == 1, "Should return 1 batch for 127 items"
+    assert len(result[0]) == 127, "Batch should contain all 127 items"
+
+
+@pytest.mark.timeout(10)
+def test_media_preparation__split_into_batches__exact_limit_returns_single_batch(create_records):
+    """Test that exactly 128 items with batch_size=128 returns single batch."""
+    records = create_records(128)
+    result = split_into_batches(records, batch_size=128)
+
+    assert len(result) == 1, "Should return 1 batch for exactly 128 items"
+    assert len(result[0]) == 128, "Batch should contain all 128 items"
+
+
+@pytest.mark.timeout(10)
+def test_media_preparation__split_into_batches__one_over_limit_returns_two_batches(create_records):
+    """Test that 129 items with batch_size=128 returns two batches."""
+    records = create_records(129)
+    result = split_into_batches(records, batch_size=128)
+
+    assert len(result) == 2, "Should return 2 batches for 129 items"
+    assert len(result[0]) == 128, "First batch should have 128 items"
+    assert len(result[1]) == 1, "Second batch should have 1 item"
+
+
+@pytest.mark.timeout(10)
+def test_media_preparation__split_into_batches__multiple_full_batches(create_records):
+    """Test that 256 items with batch_size=128 returns two full batches."""
+    records = create_records(256)
+    result = split_into_batches(records, batch_size=128)
+
+    assert len(result) == 2, "Should return 2 batches for 256 items"
+    assert len(result[0]) == 128, "First batch should have 128 items"
+    assert len(result[1]) == 128, "Second batch should have 128 items"
+
+
+@pytest.mark.timeout(10)
+def test_media_preparation__split_into_batches__invalid_batch_size_zero_returns_all(create_records):
+    """Test that batch_size=0 returns all records in single batch."""
+    records = create_records(50)
+    result = split_into_batches(records, batch_size=0)
+
+    assert len(result) == 1, "Should return 1 batch for invalid batch_size=0"
+    assert len(result[0]) == 50, "Batch should contain all 50 items"
+
+
+@pytest.mark.timeout(10)
+def test_media_preparation__split_into_batches__invalid_batch_size_negative_returns_all(create_records):
+    """Test that batch_size=-1 returns all records in single batch."""
+    records = create_records(50)
+    result = split_into_batches(records, batch_size=-1)
+
+    assert len(result) == 1, "Should return 1 batch for invalid batch_size=-1"
+    assert len(result[0]) == 50, "Batch should contain all 50 items"
+
+
+@pytest.mark.timeout(30)
+def test_media_preparation__split_into_batches__large_dataset_splits_correctly(create_records):
+    """Test that 1000 items with batch_size=128 splits into correct batches."""
+    records = create_records(1000)
+    result = split_into_batches(records, batch_size=128)
+
+    expected_batches = 8  # 1000 / 128 = 7.8125 → 8 batches
+    assert len(result) == expected_batches, f"Should return {expected_batches} batches for 1000 items"
+
+    # Verify batch sizes
+    for i in range(7):
+        assert len(result[i]) == 128, f"Batch {i} should have 128 items"
+
+    # Last batch should have remainder
+    assert len(result[7]) == 1000 - (7 * 128), "Last batch should have remainder items"
+
+    # Verify total count
+    total_items = sum(len(batch) for batch in result)
+    assert total_items == 1000, "Total items should be 1000"
+
+
+# Parametrized Tests
+
+@pytest.mark.timeout(10)
+@pytest.mark.parametrize("record_count,batch_size,expected_batches", [
+    (0, 128, 0),      # Empty
+    (1, 128, 1),      # Single
+    (50, 128, 1),     # Below limit
+    (127, 128, 1),    # One below limit
+    (128, 128, 1),    # Exact limit
+    (129, 128, 2),    # One over limit
+    (256, 128, 2),    # Two full batches
+    (257, 128, 3),    # Two full + partial
+    (500, 128, 4),    # Multiple batches
+    (1000, 100, 10),  # Different batch size
+    (1001, 100, 11),  # Different batch size + remainder
+])
+def test_media_preparation__split_into_batches__parametrized_batch_counts(
+    create_records, record_count, batch_size, expected_batches
+):
+    """Parametrized test for various record counts and batch sizes."""
+    records = create_records(record_count)
+    result = split_into_batches(records, batch_size)
+
+    assert len(result) == expected_batches, (
+        f"Expected {expected_batches} batches for {record_count} records "
+        f"with batch_size={batch_size}, got {len(result)}"
+    )
+
+
+@pytest.mark.timeout(10)
+@pytest.mark.parametrize("invalid_size", [0, -1, -10, -100])
+def test_media_preparation__split_into_batches__invalid_sizes_return_single_batch(
+    create_records, invalid_size
+):
+    """Test that various invalid batch sizes return single batch."""
+    records = create_records(50)
+    result = split_into_batches(records, batch_size=invalid_size)
+
+    assert len(result) == 1, f"Invalid batch_size={invalid_size} should return 1 batch"
+    assert len(result[0]) == 50, f"Batch should contain all items for invalid size {invalid_size}"
+
+
+# Logging Tests
+
+@pytest.mark.timeout(10)
+def test_media_preparation__split_into_batches__empty_records_logs_warning(caplog):
+    """Test that empty records triggers warning log."""
+    with caplog.at_level(logging.WARNING):
+        split_into_batches([], batch_size=128)
+
+    assert "empty records list" in caplog.text.lower(), "Should log warning for empty records"
+
+
+@pytest.mark.timeout(10)
+def test_media_preparation__split_into_batches__invalid_batch_size_logs_warning(caplog, create_records):
+    """Test that invalid batch_size triggers warning log."""
+    records = create_records(10)
+
+    with caplog.at_level(logging.WARNING):
+        split_into_batches(records, batch_size=0)
+
+    assert "invalid batch_size" in caplog.text.lower(), "Should log warning for invalid batch_size"
+
+
+@pytest.mark.timeout(10)
+def test_media_preparation__split_into_batches__valid_split_logs_info(caplog, create_records):
+    """Test that valid split logs info message."""
+    records = create_records(256)
+
+    with caplog.at_level(logging.INFO):
+        split_into_batches(records, batch_size=128)
+
+    assert "split 256 records into 2 batches" in caplog.text.lower(), "Should log info for successful split"
+
+
+# Data Integrity Tests
+
+@pytest.mark.timeout(10)
+def test_media_preparation__split_into_batches__preserves_record_order(create_records):
+    """Test that record order is preserved across batches."""
+    records = create_records(300)
+    result = split_into_batches(records, batch_size=128)
+
+    # Flatten batches back to single list
+    flattened = []
+    for batch in result:
+        flattened.extend(batch)
+
+    assert flattened == records, "Record order should be preserved"
+
+
+@pytest.mark.timeout(10)
+def test_media_preparation__split_into_batches__no_record_duplication(create_records):
+    """Test that no records are duplicated in batches."""
+    records = create_records(300)
+    result = split_into_batches(records, batch_size=128)
+
+    # Extract all filenames
+    all_filenames = []
+    for batch in result:
+        for record in batch:
+            all_filenames.append(record["Cesta"])
+
+    # Check for duplicates
+    assert len(all_filenames) == len(set(all_filenames)), "No records should be duplicated"
+
+
+@pytest.mark.timeout(10)
+def test_media_preparation__split_into_batches__no_record_loss(create_records):
+    """Test that all records are included in batches."""
+    records = create_records(300)
+    result = split_into_batches(records, batch_size=128)
+
+    total_items = sum(len(batch) for batch in result)
+    assert total_items == 300, "All records should be included in batches"
+
+
+# Boundary Tests
+
+@pytest.mark.timeout(10)
+@pytest.mark.parametrize("count", [127, 128, 129, 255, 256, 257])
+def test_media_preparation__split_into_batches__boundary_values(create_records, count):
+    """Test boundary values around batch_size=128."""
+    records = create_records(count)
+    result = split_into_batches(records, batch_size=128)
+
+    # Verify total count
+    total_items = sum(len(batch) for batch in result)
+    assert total_items == count, f"Total items should be {count}"
+
+    # Verify no batch exceeds limit
+    for i, batch in enumerate(result):
+        assert len(batch) <= 128, f"Batch {i} should not exceed 128 items"
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])

--- a/createbatch/tests/unit/test_media_preparation__split_into_batches__getty_scenarios.py
+++ b/createbatch/tests/unit/test_media_preparation__split_into_batches__getty_scenarios.py
@@ -1,0 +1,261 @@
+"""
+Unit tests for split_into_batches() function - Getty Images Scenarios
+
+Tests specific Getty Images use cases with 128-item batch limit:
+- Real PhotoMedia.csv record structures
+- Getty-specific batch sizes
+- Integration with PHOTOBANK_BATCH_SIZE_LIMITS constant
+
+Author: Unit Test Specialist
+Created: 2026-01-04
+Related: PR #120 (Getty Images batch size 128 limit)
+"""
+
+import pytest
+from typing import List, Dict
+from createbatchlib.media_preparation import split_into_batches
+from createbatchlib.constants import PHOTOBANK_BATCH_SIZE_LIMITS
+
+
+# Fixtures
+
+@pytest.fixture
+def getty_batch_limit() -> int:
+    """Getty Images batch size limit from constants."""
+    return PHOTOBANK_BATCH_SIZE_LIMITS.get('Getty Images', 128)
+
+
+@pytest.fixture
+def photomedia_record() -> Dict[str, str]:
+    """Sample PhotoMedia.csv record structure."""
+    return {
+        "Cesta": "J:/Foto/JPG/Nature/2024/01/Camera/DSC00001.jpg",
+        "Název": "Mountain landscape",
+        "Popis": "Beautiful mountain landscape at sunset",
+        "Klíčová slova": "mountain, landscape, sunset, nature",
+        "Datum pořízení": "2024-01-15 14:30:00",
+        "Getty Images status": "připraveno",
+        "Getty Images category": "Nature",
+        "Shutterstock status": "připraveno",
+        "Adobe Stock status": "připraveno"
+    }
+
+
+@pytest.fixture
+def create_photomedia_records(photomedia_record):
+    """Factory to create N PhotoMedia.csv records."""
+    def _create(count: int) -> List[Dict[str, str]]:
+        return [
+            {
+                **photomedia_record,
+                "Cesta": f"J:/Foto/JPG/Nature/2024/01/Camera/DSC{i:05d}.jpg",
+                "Název": f"Photo {i}",
+            }
+            for i in range(1, count + 1)
+        ]
+    return _create
+
+
+# Getty Specific Tests
+
+@pytest.mark.timeout(10)
+def test_media_preparation__split_into_batches__getty_limit_constant_is_128(getty_batch_limit):
+    """Verify Getty Images batch limit is set to 128 in constants."""
+    assert getty_batch_limit == 128, "Getty Images batch limit should be 128"
+
+
+@pytest.mark.timeout(10)
+def test_media_preparation__split_into_batches__getty_exact_limit(
+    create_photomedia_records, getty_batch_limit
+):
+    """Test Getty with exactly 128 items creates single batch."""
+    records = create_photomedia_records(128)
+    result = split_into_batches(records, batch_size=getty_batch_limit)
+
+    assert len(result) == 1, "128 Getty items should create 1 batch"
+    assert len(result[0]) == 128, "Batch should contain all 128 items"
+
+
+@pytest.mark.timeout(10)
+def test_media_preparation__split_into_batches__getty_one_over_limit(
+    create_photomedia_records, getty_batch_limit
+):
+    """Test Getty with 129 items creates two batches (128 + 1)."""
+    records = create_photomedia_records(129)
+    result = split_into_batches(records, batch_size=getty_batch_limit)
+
+    assert len(result) == 2, "129 Getty items should create 2 batches"
+    assert len(result[0]) == 128, "First batch should have 128 items"
+    assert len(result[1]) == 1, "Second batch should have 1 item"
+
+
+@pytest.mark.timeout(10)
+def test_media_preparation__split_into_batches__getty_typical_small_batch(
+    create_photomedia_records, getty_batch_limit
+):
+    """Test Getty with typical small batch (50 items)."""
+    records = create_photomedia_records(50)
+    result = split_into_batches(records, batch_size=getty_batch_limit)
+
+    assert len(result) == 1, "50 Getty items should create 1 batch"
+    assert len(result[0]) == 50, "Batch should contain all 50 items"
+
+
+@pytest.mark.timeout(10)
+def test_media_preparation__split_into_batches__getty_typical_large_batch(
+    create_photomedia_records, getty_batch_limit
+):
+    """Test Getty with typical large batch (300 items)."""
+    records = create_photomedia_records(300)
+    result = split_into_batches(records, batch_size=getty_batch_limit)
+
+    expected_batches = 3  # 300 / 128 = 2.34 → 3 batches
+    assert len(result) == expected_batches, f"300 Getty items should create {expected_batches} batches"
+    assert len(result[0]) == 128, "First batch should have 128 items"
+    assert len(result[1]) == 128, "Second batch should have 128 items"
+    assert len(result[2]) == 44, "Third batch should have 44 items (remainder)"
+
+
+# Real-World Scenarios
+
+@pytest.mark.timeout(10)
+@pytest.mark.parametrize("item_count,expected_batches,expected_last_batch", [
+    (1, 1, 1),        # Single photo
+    (10, 1, 10),      # Small batch
+    (50, 1, 50),      # Typical batch
+    (100, 1, 100),    # Large single batch
+    (127, 1, 127),    # Just under limit
+    (128, 1, 128),    # Exact limit
+    (129, 2, 1),      # One over
+    (200, 2, 72),     # Two batches with remainder
+    (256, 2, 128),    # Two full batches
+    (300, 3, 44),     # Three batches with remainder
+    (384, 3, 128),    # Three full batches
+    (500, 4, 116),    # Four batches with remainder
+    (1000, 8, 104),   # Large dataset
+])
+def test_media_preparation__split_into_batches__getty_real_world_scenarios(
+    create_photomedia_records, getty_batch_limit,
+    item_count, expected_batches, expected_last_batch
+):
+    """Test Getty batch splitting with real-world item counts."""
+    records = create_photomedia_records(item_count)
+    result = split_into_batches(records, batch_size=getty_batch_limit)
+
+    assert len(result) == expected_batches, (
+        f"Expected {expected_batches} batches for {item_count} Getty items"
+    )
+
+    # Verify last batch size
+    assert len(result[-1]) == expected_last_batch, (
+        f"Last batch should have {expected_last_batch} items"
+    )
+
+    # Verify all batches except last are full
+    for i in range(len(result) - 1):
+        assert len(result[i]) == getty_batch_limit, (
+            f"Batch {i} should have {getty_batch_limit} items"
+        )
+
+
+# PhotoMedia.csv Field Preservation Tests
+
+@pytest.mark.timeout(10)
+def test_media_preparation__split_into_batches__preserves_photomedia_fields(
+    create_photomedia_records, getty_batch_limit
+):
+    """Test that all PhotoMedia.csv fields are preserved in batches."""
+    records = create_photomedia_records(150)
+    result = split_into_batches(records, batch_size=getty_batch_limit)
+
+    # Check first record in first batch
+    first_record = result[0][0]
+    required_fields = [
+        "Cesta", "Název", "Popis", "Klíčová slova", "Datum pořízení",
+        "Getty Images status", "Getty Images category",
+        "Shutterstock status", "Adobe Stock status"
+    ]
+
+    for field in required_fields:
+        assert field in first_record, f"Field '{field}' should be preserved"
+
+
+@pytest.mark.timeout(10)
+def test_media_preparation__split_into_batches__photomedia_record_integrity(
+    create_photomedia_records, getty_batch_limit
+):
+    """Test that PhotoMedia.csv records maintain integrity across batches."""
+    records = create_photomedia_records(200)
+    original_paths = [r["Cesta"] for r in records]
+
+    result = split_into_batches(records, batch_size=getty_batch_limit)
+
+    # Flatten and extract paths
+    flattened_paths = []
+    for batch in result:
+        for record in batch:
+            flattened_paths.append(record["Cesta"])
+
+    assert flattened_paths == original_paths, "Record paths should maintain order"
+    assert len(flattened_paths) == len(set(flattened_paths)), "No duplicate records"
+
+
+# Performance Expectations
+
+@pytest.mark.timeout(10)
+def test_media_preparation__split_into_batches__getty_max_single_batch_completes_quickly(
+    create_photomedia_records, getty_batch_limit
+):
+    """Test that splitting 128 Getty items completes quickly."""
+    records = create_photomedia_records(128)
+
+    import time
+    start = time.time()
+    result = split_into_batches(records, batch_size=getty_batch_limit)
+    duration = time.time() - start
+
+    assert duration < 1.0, "Splitting 128 items should take < 1 second"
+    assert len(result) == 1, "Should create 1 batch"
+
+
+@pytest.mark.timeout(30)
+def test_media_preparation__split_into_batches__getty_large_dataset_completes_quickly(
+    create_photomedia_records, getty_batch_limit
+):
+    """Test that splitting 1000 Getty items completes quickly."""
+    records = create_photomedia_records(1000)
+
+    import time
+    start = time.time()
+    result = split_into_batches(records, batch_size=getty_batch_limit)
+    duration = time.time() - start
+
+    assert duration < 2.0, "Splitting 1000 items should take < 2 seconds"
+    assert len(result) == 8, "Should create 8 batches"
+
+
+# Edge Cases with Getty Limit
+
+@pytest.mark.timeout(10)
+def test_media_preparation__split_into_batches__getty_empty_records_safe(getty_batch_limit):
+    """Test that empty Getty records list is handled safely."""
+    result = split_into_batches([], batch_size=getty_batch_limit)
+
+    assert result == [], "Empty Getty records should return empty list"
+
+
+@pytest.mark.timeout(10)
+def test_media_preparation__split_into_batches__getty_single_photo(
+    photomedia_record, getty_batch_limit
+):
+    """Test that single Getty photo creates single batch."""
+    records = [photomedia_record]
+    result = split_into_batches(records, batch_size=getty_batch_limit)
+
+    assert len(result) == 1, "Single Getty photo should create 1 batch"
+    assert len(result[0]) == 1, "Batch should contain 1 item"
+    assert result[0][0]["Getty Images status"] == "připraveno"
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])

--- a/createbatch/tests/unit/test_optimization__compare_with_legacy.py
+++ b/createbatch/tests/unit/test_optimization__compare_with_legacy.py
@@ -1,0 +1,40 @@
+"""
+Unit tests for compare_with_legacy_approach.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+createbatch_root = project_root / "createbatch"
+sys.path.insert(0, str(createbatch_root))
+
+import createbatchlib.optimization as opt_module
+
+
+class DummyTqdm:
+    def __init__(self, iterable=None, desc=None, unit=None):
+        self.iterable = iterable
+
+    def __iter__(self):
+        return iter(self.iterable or [])
+
+
+def test_compare_with_legacy_approach__matches_results(monkeypatch):
+    monkeypatch.setattr(opt_module, "tqdm", DummyTqdm)
+
+    records = [
+        {"Cesta": "C:/Photos/a.jpg", "Shutterstock Status": "připraveno"},
+        {"Cesta": "C:/Photos/b.jpg", "Adobe Stock Status": "připraveno"},
+        {"Cesta": "C:/Photos/upraven‚/c.jpg", "Shutterstock Status": "připraveno"},
+    ]
+
+    optimized, legacy = opt_module.compare_with_legacy_approach(
+        records,
+        status_keyword="status",
+        prepared_value="připraveno",
+        include_edited=False,
+    )
+
+    assert optimized == legacy
+    assert set(optimized.keys()) == {"Adobe Stock", "Shutterstock"}

--- a/createbatch/tests/unit/test_progress_tracker__scenarios.py
+++ b/createbatch/tests/unit/test_progress_tracker__scenarios.py
@@ -1,0 +1,52 @@
+"""
+Unit tests for UnifiedProgressTracker.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+createbatch_root = project_root / "createbatch"
+sys.path.insert(0, str(createbatch_root))
+
+import createbatchlib.progress_tracker as tracker_module
+
+
+class DummyTqdm:
+    def __init__(self, total, desc, unit, position=0, leave=True):
+        self.total = total
+        self.desc = desc
+        self.unit = unit
+        self.position = position
+        self.leave = leave
+        self.updates = 0
+        self.closed = False
+
+    def update(self, count):
+        self.updates += count
+
+    def close(self):
+        self.closed = True
+
+
+def test_progress_tracker__tracks_updates(monkeypatch):
+    monkeypatch.setattr(tracker_module, "tqdm", DummyTqdm)
+
+    tracker = tracker_module.UnifiedProgressTracker(["A", "B"], {"A": 2, "B": 1})
+    tracker.start_bank("A")
+    tracker.update_progress(1)
+    tracker.finish_bank()
+    tracker.start_bank("B")
+    tracker.update_progress(1)
+    tracker.finish_all()
+
+    assert tracker.processed_records == 2
+    assert tracker.main_pbar is None
+
+
+def test_progress_tracker__summary_zero_total(monkeypatch):
+    monkeypatch.setattr(tracker_module, "tqdm", DummyTqdm)
+
+    tracker = tracker_module.UnifiedProgressTracker([], {})
+
+    assert tracker.get_summary() == "Processed 0/0 files (0.0%)"

--- a/createbatch/tests/unit/test_update_exif_data__scenarios.py
+++ b/createbatch/tests/unit/test_update_exif_data__scenarios.py
@@ -1,0 +1,120 @@
+"""
+Unit tests for update_exif_data and load_extensions.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+createbatch_root = project_root / "createbatch"
+sys.path.insert(0, str(createbatch_root))
+
+import createbatchlib.update_exif_data as exif_module
+
+
+class DummyTqdm:
+    def __init__(self, total, desc, unit):
+        self.total = total
+        self.desc = desc
+        self.unit = unit
+
+    def update(self, _count):
+        return None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class DummyResult:
+    def __init__(self, returncode=0):
+        self.returncode = returncode
+        self.stdout = "ok"
+        self.stderr = ""
+
+    def check_returncode(self):
+        if self.returncode != 0:
+            raise RuntimeError("exiftool failed")
+
+
+def test_load_extensions__reads_lines(tmp_path):
+    file_path = tmp_path / "ext.txt"
+    file_path.write_text("jpg\npng\n", encoding="utf-8")
+
+    result = exif_module.load_extensions(str(file_path))
+
+    assert result == ["jpg", "png"]
+
+
+def test_load_extensions__error_exits(monkeypatch):
+    def fail_open(*_args, **_kwargs):
+        raise OSError("nope")
+
+    monkeypatch.setattr(exif_module, "open", fail_open)
+
+    with pytest.raises(SystemExit) as excinfo:
+        exif_module.load_extensions("missing.txt")
+
+    assert excinfo.value.code == 1
+
+
+def test_update_exif_data__skips_unsupported(monkeypatch, caplog):
+    monkeypatch.setattr(exif_module, "tqdm", DummyTqdm)
+    monkeypatch.setattr(exif_module, "load_extensions", lambda _path: ["jpg"])
+
+    run_calls = []
+
+    def fake_run(*_args, **_kwargs):
+        run_calls.append(True)
+        return DummyResult()
+
+    monkeypatch.setattr(exif_module.subprocess, "run", fake_run)
+
+    items = [{"Cesta": "file.txt"}]
+
+    with caplog.at_level("WARNING"):
+        exif_module.update_exif_data(items, "C:/Tools")
+
+    assert "unsupported file type" in caplog.text.lower()
+    assert run_calls == []
+
+
+def test_update_exif_data__runs_exiftool_for_supported(monkeypatch):
+    monkeypatch.setattr(exif_module, "tqdm", DummyTqdm)
+    monkeypatch.setattr(exif_module, "load_extensions", lambda _path: ["jpg"])
+
+    run_args = {}
+
+    def fake_run(command, capture_output, text):
+        run_args["command"] = command
+        run_args["capture_output"] = capture_output
+        run_args["text"] = text
+        return DummyResult()
+
+    monkeypatch.setattr(exif_module.subprocess, "run", fake_run)
+
+    items = [{"Cesta": "photo.jpg", "N zev": "Title", "Kl¡Ÿov  slova": "kw", "Popis": "Desc"}]
+    exif_module.update_exif_data(items, "C:/Tools")
+
+    assert "exiftool-12.30" in run_args["command"][0]
+    assert "photo.jpg" in run_args["command"]
+
+
+def test_update_exif_data__run_failure_logged(monkeypatch, caplog):
+    monkeypatch.setattr(exif_module, "tqdm", DummyTqdm)
+    monkeypatch.setattr(exif_module, "load_extensions", lambda _path: ["jpg"])
+
+    def fake_run(*_args, **_kwargs):
+        return DummyResult(returncode=1)
+
+    monkeypatch.setattr(exif_module.subprocess, "run", fake_run)
+
+    items = [{"Cesta": "photo.jpg"}]
+    with caplog.at_level("ERROR"):
+        exif_module.update_exif_data(items, "C:/Tools")
+
+    assert "error updating exif data for" in caplog.text.lower()

--- a/exportpreparedmedia/tests/integration/test_main_pipeline__filters_and_exports.py
+++ b/exportpreparedmedia/tests/integration/test_main_pipeline__filters_and_exports.py
@@ -1,0 +1,60 @@
+"""
+Integration tests for exportpreparedmedia main flow.
+"""
+
+import types
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "exportpreparedmedia"
+sys.path.insert(0, str(package_root))
+
+import exportpreparedmedia
+
+
+def test_main_filters_edited_items(monkeypatch):
+    args = types.SimpleNamespace(
+        photo_csv="X:/photo.csv",
+        output_dir="X:/out",
+        output_prefix="CSV",
+        log_dir="X:/logs",
+        debug=False,
+        overwrite=False,
+        shutterstock=True,
+        adobestock=False,
+        dreamstime=False,
+        depositphotos=False,
+        bigstockphoto=False,
+        _123rf=False,
+        canstockphoto=False,
+        pond5=False,
+        gettyimages=False,
+        alamy=False,
+        all=False,
+        include_edited=False,
+        include_alternative_formats=False,
+    )
+
+    items = [
+        {"Cesta": "C:/photos/original.jpg", "status": "kontrolovano"},
+        {"Cesta": "C:/photos/upraveno/edited.jpg", "status": "kontrolovano"},
+    ]
+
+    captured = {"count": 0}
+
+    monkeypatch.setattr(exportpreparedmedia, "parse_arguments", lambda: args)
+    monkeypatch.setattr(exportpreparedmedia, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(exportpreparedmedia, "get_log_filename", lambda _p: "log.txt")
+    monkeypatch.setattr(exportpreparedmedia, "setup_logging", lambda **_k: None)
+    monkeypatch.setattr(exportpreparedmedia, "get_enabled_banks", lambda _a: ["ShutterStock"])
+    monkeypatch.setattr(exportpreparedmedia, "get_output_paths", lambda *_a, **_k: {"ShutterStock": "out.csv"})
+    monkeypatch.setattr(exportpreparedmedia, "load_csv", lambda _p: items)
+
+    def fake_export(filtered_items, *_a, **_k):
+        captured["count"] = len(filtered_items)
+
+    monkeypatch.setattr(exportpreparedmedia, "export_to_photobanks", fake_export)
+
+    exportpreparedmedia.main()
+    assert captured["count"] == 1

--- a/exportpreparedmedia/tests/performance/test_is_not_edited__bulk.py
+++ b/exportpreparedmedia/tests/performance/test_is_not_edited__bulk.py
@@ -1,0 +1,18 @@
+"""
+Performance-oriented tests for _is_not_edited filter.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "exportpreparedmedia"
+sys.path.insert(0, str(package_root))
+
+from exportpreparedmedia import _is_not_edited
+
+
+def test_is_not_edited_bulk():
+    items = [{"Cesta": f"C:/photos/file_{i}.jpg"} for i in range(500)]
+    results = [_is_not_edited(item) for item in items]
+    assert all(results)

--- a/exportpreparedmedia/tests/security/test_main__rejects_all_with_individual.py
+++ b/exportpreparedmedia/tests/security/test_main__rejects_all_with_individual.py
@@ -1,0 +1,45 @@
+"""
+Security-focused tests for mutually exclusive flags.
+"""
+
+import types
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "exportpreparedmedia"
+sys.path.insert(0, str(package_root))
+
+import exportpreparedmedia
+
+
+def test_main_rejects_all_with_individual(monkeypatch):
+    args = types.SimpleNamespace(
+        photo_csv="X:/photo.csv",
+        output_dir="X:/out",
+        output_prefix="CSV",
+        log_dir="X:/logs",
+        debug=False,
+        overwrite=False,
+        shutterstock=True,
+        adobestock=False,
+        dreamstime=False,
+        depositphotos=False,
+        bigstockphoto=False,
+        _123rf=False,
+        canstockphoto=False,
+        pond5=False,
+        gettyimages=False,
+        alamy=False,
+        all=True,
+        include_edited=False,
+        include_alternative_formats=False,
+    )
+
+    called = {"export": False}
+
+    monkeypatch.setattr(exportpreparedmedia, "parse_arguments", lambda: args)
+    monkeypatch.setattr(exportpreparedmedia, "export_to_photobanks", lambda *_a, **_k: called.__setitem__("export", True))
+
+    exportpreparedmedia.main()
+    assert called["export"] is False

--- a/exportpreparedmedia/tests/unit/__init__.py
+++ b/exportpreparedmedia/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests package for exportpreparedmedia."""

--- a/exportpreparedmedia/tests/unit/test_banks_logic__scenarios.py
+++ b/exportpreparedmedia/tests/unit/test_banks_logic__scenarios.py
@@ -1,0 +1,119 @@
+"""
+Unit tests for exportpreparedmedialib/banks_logic.py.
+"""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+export_root = project_root / "exportpreparedmedia"
+sys.path.insert(0, str(export_root))
+
+import exportpreparedmedialib.banks_logic as banks_logic
+from exportpreparedmedialib import constants as exp_constants
+
+
+def test_get_enabled_banks__maps_flags():
+    args = SimpleNamespace(
+        shutterstock=True,
+        adobestock=True,
+        dreamstime=False,
+        depositphotos=False,
+        bigstockphoto=False,
+        _123rf=True,
+        canstockphoto=False,
+        pond5=False,
+        gettyimages=False,
+        alamy=False,
+    )
+
+    banks = banks_logic.get_enabled_banks(args)
+
+    assert banks == ["ShutterStock", "AdobeStock", "123RF"]
+
+
+def test_get_output_paths__builds_paths(tmp_path):
+    output = banks_logic.get_output_paths(["ShutterStock"], str(tmp_path), "CSV")
+
+    assert output["ShutterStock"].endswith("CSV_ShutterStock.csv")
+
+
+def test_should_include_item__bank_specific_status():
+    item = {"ShutterStock Status": exp_constants.VALID_STATUS}
+    assert banks_logic.should_include_item(item, bank="ShutterStock") is True
+
+
+def test_should_include_item__general_status():
+    item = {"Some Status": exp_constants.VALID_STATUS}
+    assert banks_logic.should_include_item(item) is True
+
+
+def test_should_include_item__missing_status_false():
+    item = {"Title": "x"}
+    assert banks_logic.should_include_item(item) is False
+
+
+def test_load_category_map__returns_map(monkeypatch):
+    monkeypatch.setattr(banks_logic, "load_csv", lambda _p: [{"k": "a", "v": "1"}])
+
+    result = banks_logic.load_category_map("file.csv", "k", "v")
+
+    assert result == {"a": "1"}
+
+
+def test_load_category_map__error_returns_empty(monkeypatch):
+    def fail_load(_p):
+        raise OSError("fail")
+
+    monkeypatch.setattr(banks_logic, "load_csv", fail_load)
+    assert banks_logic.load_category_map("file.csv", "k", "v") == {}
+
+
+def test_load_pond_prices__defaults_on_error(monkeypatch):
+    def fail_load(_p):
+        raise OSError("fail")
+
+    monkeypatch.setattr(banks_logic, "load_csv", fail_load)
+    prices = banks_logic.load_pond_prices("file.csv")
+
+    assert prices.get("jpg") == "5"
+    assert prices.get("mp4") == "30"
+
+
+def test_remove_duplicate_keywords__removes_short_and_dups():
+    result = banks_logic.remove_duplicate_keywords("a, aa, cat, cat, dog, do")
+    assert "cat" in result
+    assert "dog" in result
+    assert "aa" not in result
+
+
+def test_get_pond_price__default_rules():
+    assert banks_logic.get_pond_price("file.tif") == "10"
+    assert banks_logic.get_pond_price("file.mp4") == "30"
+    assert banks_logic.get_pond_price("file.jpg") == "5"
+
+
+def test_get_pond_price__map_override():
+    prices = {"jpg": "7"}
+    assert banks_logic.get_pond_price("file.jpg", prices) == "7"
+
+
+def test_extract_media_properties__basic_fields():
+    item = {
+        "Soubor": "photo.jpg",
+        "N zev": "Title",
+        "Popis": "Desc",
+        "Kl¡Ÿov  slova": "cat, dog, cat",
+        "Datum vytvoýen¡": "01.02.2020",
+    }
+
+    result = banks_logic.extract_media_properties(item, category_maps={})
+
+    assert result["filename"] == "photo.jpg"
+    assert result["title"] == "Title"
+    assert result["description"] == "Desc"
+    assert result["year"] == "2020"
+    assert result["getty_date"].startswith("02/01/2020")

--- a/exportpreparedmedia/tests/unit/test_category_handler__scenarios.py
+++ b/exportpreparedmedia/tests/unit/test_category_handler__scenarios.py
@@ -1,0 +1,15 @@
+"""
+Unit tests for exportpreparedmedialib/category_handler.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+export_root = project_root / "exportpreparedmedia"
+sys.path.insert(0, str(export_root))
+
+
+def test_category_handler__import_and_basic_usage():
+    # Import inside test so a SyntaxError is surfaced as a test failure.
+    import exportpreparedmedialib.category_handler as category_handler  # noqa: F401

--- a/exportpreparedmedia/tests/unit/test_column_maps__scenarios.py
+++ b/exportpreparedmedia/tests/unit/test_column_maps__scenarios.py
@@ -1,0 +1,48 @@
+"""
+Unit tests for exportpreparedmedialib/column_maps.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+export_root = project_root / "exportpreparedmedia"
+sys.path.insert(0, str(export_root))
+
+from exportpreparedmedialib.column_maps import (
+    editorial_to_numeric,
+    get_super_tags,
+    check_people,
+    check_property,
+    license_type_from_editorial,
+    get_column_map,
+)
+
+
+def test_editorial_to_numeric():
+    assert editorial_to_numeric("yes") == "1"
+    assert editorial_to_numeric("no") == "0"
+
+
+def test_get_super_tags():
+    assert get_super_tags("a,b,c") == "a,b,c"
+    assert get_super_tags("") == ""
+
+
+def test_check_people():
+    assert check_people("people on street") == "crowd"
+    assert check_people("no one") == "0"
+
+
+def test_check_property():
+    assert check_property("house exterior") == "Y"
+    assert check_property("trees") == "N"
+
+
+def test_license_type_from_editorial():
+    assert license_type_from_editorial("yes") == "RF-E"
+    assert license_type_from_editorial("no") == "RF"
+
+
+def test_get_column_map__unknown_returns_empty():
+    assert get_column_map("Unknown") == []

--- a/exportpreparedmedia/tests/unit/test_export_objects__scenarios.py
+++ b/exportpreparedmedia/tests/unit/test_export_objects__scenarios.py
@@ -1,0 +1,39 @@
+"""
+Unit tests for exportpreparedmedialib/export_objects.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+export_root = project_root / "exportpreparedmedia"
+sys.path.insert(0, str(export_root))
+
+import exportpreparedmedialib.export_objects as export_objects
+
+
+def test_base_export__to_dict_maps_headers(monkeypatch):
+    monkeypatch.setattr(
+        export_objects,
+        "HEADER_MAPPINGS",
+        {"ShutterStock": {"title": "Title"}},
+    )
+
+    exp = export_objects.BaseExport("ShutterStock", title="T", other="X")
+    result = exp.to_dict()
+
+    assert result["Title"] == "T"
+    assert result["other"] == "X"
+
+
+def test_subclasses__photobank_name():
+    assert export_objects.ShutterStockExport().photobank == "ShutterStock"
+    assert export_objects.AdobeStockExport().photobank == "AdobeStock"
+    assert export_objects.DreamstimeExport().photobank == "Dreamstime"
+    assert export_objects.DepositPhotosExport().photobank == "DepositPhotos"
+    assert export_objects.BigStockPhotoExport().photobank == "BigStockPhoto"
+    assert export_objects.RF123Export().photobank == "123RF"
+    assert export_objects.CanStockPhotoExport().photobank == "CanStockPhoto"
+    assert export_objects.Pond5Export().photobank == "Pond5"
+    assert export_objects.AlamyExport().photobank == "Alamy"
+    assert export_objects.GettyImagesExport().photobank == "GettyImages"

--- a/exportpreparedmedia/tests/unit/test_export_processor__scenarios.py
+++ b/exportpreparedmedia/tests/unit/test_export_processor__scenarios.py
@@ -1,0 +1,15 @@
+"""
+Unit tests for exportpreparedmedialib/export_processor.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+export_root = project_root / "exportpreparedmedia"
+sys.path.insert(0, str(export_root))
+
+
+def test_export_processor__import_and_basic_usage():
+    # Import inside test so missing dependencies raise during test execution.
+    import exportpreparedmedialib.export_processor as export_processor  # noqa: F401

--- a/exportpreparedmedia/tests/unit/test_exporters__scenarios.py
+++ b/exportpreparedmedia/tests/unit/test_exporters__scenarios.py
@@ -1,0 +1,79 @@
+"""
+Unit tests for exportpreparedmedialib/exporters.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+export_root = project_root / "exportpreparedmedia"
+sys.path.insert(0, str(export_root))
+
+import exportpreparedmedialib.exporters as exporters
+
+
+def test_expand_item_with_alternative_formats__missing_source(tmp_path):
+    item = {"Cesta": str(tmp_path / "missing.jpg")}
+    result = exporters.expand_item_with_alternative_formats(item, "Pond5", include_alternatives=True)
+    assert result == []
+
+
+def test_expand_item_with_alternative_formats__adds_alternative(tmp_path):
+    source = tmp_path / "JPG" / "set" / "image.jpg"
+    alt = tmp_path / "PNG" / "set" / "image.png"
+    source.parent.mkdir(parents=True)
+    alt.parent.mkdir(parents=True)
+    source.write_text("x", encoding="utf-8")
+    alt.write_text("y", encoding="utf-8")
+
+    item = {"Cesta": str(source), "Soubor": source.name}
+    result = exporters.expand_item_with_alternative_formats(item, "Pond5", include_alternatives=True)
+
+    assert len(result) == 2
+    assert any(r["Cesta"] == str(alt) for r in result)
+
+
+def test_load_photobank_headers__decodes_delimiter(monkeypatch):
+    monkeypatch.setattr(exporters, "load_csv", lambda _p: [{"bank": "X", "headers": "A,B", "delimiter": "\\t"}])
+
+    formats = exporters.load_photobank_headers("file.csv")
+
+    assert formats["X"]["delimiter"] == "\t"
+
+
+def test_export_mediafile__missing_required_sources(monkeypatch, tmp_path):
+    monkeypatch.setattr(exporters, "get_column_map", lambda _b: [{"target": "A", "source": "missing"}])
+    monkeypatch.setattr(exporters, "sanitize_field", lambda v: v)
+
+    output = tmp_path / "out.csv"
+    result = exporters.export_mediafile("X", {"filename": "a.jpg"}, str(output), {})
+
+    assert result is False
+
+
+def test_export_mediafile__writes_header(monkeypatch, tmp_path):
+    monkeypatch.setattr(exporters, "get_column_map", lambda _b: [{"target": "A", "source": "a"}])
+    monkeypatch.setattr(exporters, "sanitize_field", lambda v: v)
+
+    output = tmp_path / "out.csv"
+    record = {"a": "1"}
+    result = exporters.export_mediafile("X", record, str(output), {"X": {"delimiter": ","}})
+
+    content = output.read_text(encoding="utf-8")
+    assert result is True
+    assert "A" in content
+
+
+def test_export_to_photobanks__batch_split(monkeypatch, tmp_path):
+    items = [{"Cesta": str(tmp_path / "a.jpg")}]
+    output_paths = {"X": str(tmp_path / "out.csv")}
+
+    monkeypatch.setattr(exporters, "load_photobank_headers", lambda _p: {"X": {"headers": "A", "delimiter": ","}})
+    monkeypatch.setattr(exporters, "load_category_map", lambda *_a, **_k: {})
+    monkeypatch.setattr(exporters, "load_pond_prices", lambda *_a, **_k: {})
+    monkeypatch.setattr(exporters, "extract_media_properties", lambda *_a, **_k: {"filename": "a.jpg"})
+    monkeypatch.setattr(exporters, "expand_item_with_alternative_formats", lambda item, bank, include_alternatives: [item])
+    monkeypatch.setattr(exporters, "export_mediafile", lambda *_a, **_k: True)
+    monkeypatch.setattr(exporters, "PHOTOBANK_BATCH_SIZE_LIMITS", {"X": 1})
+
+    exporters.export_to_photobanks(items, ["X"], output_paths, filter_func=None, include_alternative_formats=False)

--- a/exportpreparedmedia/tests/unit/test_exportpreparedmedia__main__scenarios.py
+++ b/exportpreparedmedia/tests/unit/test_exportpreparedmedia__main__scenarios.py
@@ -1,0 +1,134 @@
+"""
+Unit tests for exportpreparedmedia.py.
+"""
+
+import logging
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+export_root = project_root / "exportpreparedmedia"
+sys.path.insert(0, str(export_root))
+
+import exportpreparedmedia as export_module
+from exportpreparedmedialib import constants as exp_constants
+
+
+def make_args(tmp_path, **overrides):
+    defaults = dict(
+        photo_csv=str(tmp_path / "input.csv"),
+        output_dir=str(tmp_path / "out"),
+        output_prefix="CSV",
+        log_dir=str(tmp_path / "logs"),
+        debug=False,
+        overwrite=False,
+        shutterstock=False,
+        adobestock=False,
+        dreamstime=False,
+        depositphotos=False,
+        bigstockphoto=False,
+        _123rf=False,
+        canstockphoto=False,
+        pond5=False,
+        gettyimages=False,
+        alamy=False,
+        all=False,
+        include_edited=False,
+        include_alternative_formats=False,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def test_is_not_edited__detects_marker():
+    assert export_module._is_not_edited({"Cesta": "C:/Photos/upraven‚/img.jpg"}) is False
+    assert export_module._is_not_edited({"Cesta": "C:/Photos/original/img.jpg"}) is True
+
+
+def test_parse_arguments__defaults(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["exportpreparedmedia.py"])
+    args = export_module.parse_arguments()
+
+    assert args.photo_csv == exp_constants.DEFAULT_PHOTO_CSV
+    assert args.output_dir == exp_constants.DEFAULT_OUTPUT_DIR
+    assert args.output_prefix == exp_constants.DEFAULT_OUTPUT_PREFIX
+    assert args.log_dir == exp_constants.DEFAULT_LOG_DIR
+    assert args.debug is False
+
+
+def test_main__all_with_individual_logs_error(monkeypatch, caplog, tmp_path):
+    args = make_args(tmp_path, all=True, shutterstock=True)
+    monkeypatch.setattr(export_module, "parse_arguments", lambda: args)
+
+    with caplog.at_level(logging.ERROR):
+        export_module.main()
+
+    assert "cannot use --all" in caplog.text.lower()
+
+
+def test_main__no_enabled_banks_warns(monkeypatch, caplog, tmp_path):
+    args = make_args(tmp_path)
+    monkeypatch.setattr(export_module, "parse_arguments", lambda: args)
+    monkeypatch.setattr(export_module, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(export_module, "get_log_filename", lambda _p: "log.txt")
+    monkeypatch.setattr(export_module, "setup_logging", lambda **_k: None)
+    monkeypatch.setattr(export_module, "get_enabled_banks", lambda _a: [])
+
+    with caplog.at_level(logging.WARNING):
+        export_module.main()
+
+    assert "no banks enabled" in caplog.text.lower()
+
+
+def test_main__load_csv_error_logs(monkeypatch, caplog, tmp_path):
+    args = make_args(tmp_path, shutterstock=True)
+    monkeypatch.setattr(export_module, "parse_arguments", lambda: args)
+    monkeypatch.setattr(export_module, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(export_module, "get_log_filename", lambda _p: "log.txt")
+    monkeypatch.setattr(export_module, "setup_logging", lambda **_k: None)
+    monkeypatch.setattr(export_module, "get_enabled_banks", lambda _a: ["ShutterStock"])
+    monkeypatch.setattr(export_module, "get_output_paths", lambda _b, _d, _p: {"ShutterStock": "out.csv"})
+
+    def fail_load(_p):
+        raise OSError("fail")
+
+    monkeypatch.setattr(export_module, "load_csv", fail_load)
+
+    with caplog.at_level(logging.ERROR):
+        export_module.main()
+
+    assert "failed to load input csv" in caplog.text.lower()
+
+
+def test_main__filters_edited_and_exports(monkeypatch, tmp_path):
+    args = make_args(tmp_path, shutterstock=True, include_edited=False, include_alternative_formats=True)
+    monkeypatch.setattr(export_module, "parse_arguments", lambda: args)
+    monkeypatch.setattr(export_module, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(export_module, "get_log_filename", lambda _p: "log.txt")
+    monkeypatch.setattr(export_module, "setup_logging", lambda **_k: None)
+    monkeypatch.setattr(export_module, "get_enabled_banks", lambda _a: ["ShutterStock"])
+    monkeypatch.setattr(export_module, "get_output_paths", lambda _b, _d, _p: {"ShutterStock": "out.csv"})
+    monkeypatch.setattr(export_module, "should_include_item", lambda _i, _b=None: True)
+    monkeypatch.setattr(export_module, "load_csv", lambda _p: [
+        {"Cesta": "C:/Photos/upraven‚/img.jpg"},
+        {"Cesta": "C:/Photos/original/img.jpg"},
+    ])
+
+    captured = {}
+
+    def fake_export(items, banks, output_paths, filter_func, include_alternative_formats):
+        captured["items"] = items
+        captured["banks"] = banks
+        captured["output_paths"] = output_paths
+        captured["include_alternative_formats"] = include_alternative_formats
+
+    monkeypatch.setattr(export_module, "export_to_photobanks", fake_export)
+
+    export_module.main()
+
+    assert captured["banks"] == ["ShutterStock"]
+    assert len(captured["items"]) == 1
+    assert captured["include_alternative_formats"] is True

--- a/exportpreparedmedia/tests/unit/test_exportpreparedmedia_constants__sanity.py
+++ b/exportpreparedmedia/tests/unit/test_exportpreparedmedia_constants__sanity.py
@@ -1,0 +1,28 @@
+"""
+Unit tests for exportpreparedmedialib/constants.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+export_root = project_root / "exportpreparedmedia"
+sys.path.insert(0, str(export_root))
+
+from exportpreparedmedialib import constants
+
+
+def test_constants__types_and_names():
+    assert isinstance(constants.DEFAULT_PHOTO_CSV, str)
+    assert isinstance(constants.DEFAULT_OUTPUT_DIR, str)
+    assert isinstance(constants.DEFAULT_OUTPUT_PREFIX, str)
+    assert isinstance(constants.PHOTOBANKS, list)
+
+
+def test_constants__jpg_supported():
+    for bank, formats in constants.PHOTOBANK_SUPPORTED_FORMATS.items():
+        assert ".jpg" in formats, f"{bank} should support .jpg"
+
+
+def test_constants__export_formats_override():
+    assert "DreamsTime" in constants.PHOTOBANK_EXPORT_FORMATS

--- a/exportpreparedmedia/tests/unit/test_header_mappings__sanity.py
+++ b/exportpreparedmedia/tests/unit/test_header_mappings__sanity.py
@@ -1,0 +1,22 @@
+"""
+Unit tests for exportpreparedmedialib/header_mappings.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+export_root = project_root / "exportpreparedmedia"
+sys.path.insert(0, str(export_root))
+
+from exportpreparedmedialib.header_mappings import HEADER_MAPPINGS
+
+
+def test_header_mappings__banks_present():
+    for bank in ["ShutterStock", "AdobeStock", "DreamsTime", "Pond5", "Alamy", "GettyImages"]:
+        assert bank in HEADER_MAPPINGS
+
+
+def test_header_mappings__required_keys():
+    assert "Filename" in HEADER_MAPPINGS["ShutterStock"]
+    assert "Filename" in HEADER_MAPPINGS["AdobeStock"]

--- a/exportpreparedmedia/tests/unit/test_shared_csv_handler__scenarios.py
+++ b/exportpreparedmedia/tests/unit/test_shared_csv_handler__scenarios.py
@@ -1,0 +1,15 @@
+"""
+Unit tests for exportpreparedmedia/shared/csv_handler.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+export_root = project_root / "exportpreparedmedia"
+sys.path.insert(0, str(export_root))
+
+
+def test_csv_handler__import_and_basic_usage():
+    # Import inside test so missing dependencies raise during test execution.
+    import shared.csv_handler as csv_handler  # noqa: F401

--- a/exportpreparedmedia/tests/unit/test_shared_csv_sanitizer__scenarios.py
+++ b/exportpreparedmedia/tests/unit/test_shared_csv_sanitizer__scenarios.py
@@ -1,0 +1,36 @@
+"""
+Unit tests for exportpreparedmedia/shared/csv_sanitizer.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+export_root = project_root / "exportpreparedmedia"
+sys.path.insert(0, str(export_root))
+
+from shared.csv_sanitizer import sanitize_field, sanitize_record, sanitize_records, is_dangerous
+
+
+def test_sanitize_field__basic():
+    assert sanitize_field("text") == "text"
+    assert sanitize_field("") == ""
+    assert sanitize_field(None) == ""
+    assert sanitize_field(123) == "123"
+
+
+def test_sanitize_field__dangerous():
+    assert sanitize_field("=1+1") == "'=1+1"
+    assert sanitize_field("+1+1") == "'+1+1"
+    assert sanitize_field("cmd|calc") == "'cmd|calc"
+
+
+def test_sanitize_record_and_records():
+    record = {"a": "=1+1", "b": "ok"}
+    assert sanitize_record(record)["a"].startswith("'")
+    assert sanitize_records([record])[0]["b"] == "ok"
+
+
+def test_is_dangerous():
+    assert is_dangerous("=1+1") is True
+    assert is_dangerous("normal") is False

--- a/exportpreparedmedia/tests/unit/test_shared_file_operations__scenarios.py
+++ b/exportpreparedmedia/tests/unit/test_shared_file_operations__scenarios.py
@@ -1,0 +1,127 @@
+"""
+Unit tests for exportpreparedmedia/shared/file_operations.py.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+export_root = project_root / "exportpreparedmedia"
+sys.path.insert(0, str(export_root))
+
+import shared.file_operations as file_ops
+
+
+class DummyTqdm:
+    def __init__(self, iterable=None, total=None, desc=None, unit=None):
+        self.iterable = iterable
+
+    def __iter__(self):
+        return iter(self.iterable or [])
+
+
+@pytest.fixture
+def patch_tqdm(monkeypatch):
+    monkeypatch.setattr(file_ops, "tqdm", DummyTqdm)
+
+
+def test_list_files__recursive_and_non_recursive(tmp_path):
+    (tmp_path / "a.txt").write_text("a", encoding="utf-8")
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    (nested / "b.txt").write_text("b", encoding="utf-8")
+
+    all_files = file_ops.list_files(str(tmp_path), recursive=True)
+    top_files = file_ops.list_files(str(tmp_path), recursive=False)
+
+    assert any("a.txt" in p for p in all_files)
+    assert any("b.txt" in p for p in all_files)
+    assert any("a.txt" in p for p in top_files)
+    assert not any("b.txt" in p for p in top_files)
+
+
+def test_copy_file__creates_dest_dir(tmp_path):
+    source = tmp_path / "src.txt"
+    source.write_text("data", encoding="utf-8")
+    dest = tmp_path / "out" / "dest.txt"
+
+    file_ops.copy_file(str(source), str(dest), overwrite=True)
+
+    assert dest.exists()
+
+
+def test_move_file__skips_when_dest_exists(tmp_path):
+    source = tmp_path / "src.txt"
+    source.write_text("src", encoding="utf-8")
+    dest = tmp_path / "dest.txt"
+    dest.write_text("dest", encoding="utf-8")
+
+    file_ops.move_file(str(source), str(dest), overwrite=False)
+
+    assert dest.read_text(encoding="utf-8") == "dest"
+    assert source.exists()
+
+
+def test_ensure_directory__creates(tmp_path):
+    target = tmp_path / "newdir"
+    file_ops.ensure_directory(str(target))
+    assert target.exists()
+
+
+def test_load_csv__header_only(tmp_path, patch_tqdm):
+    csv_path = tmp_path / "data.csv"
+    csv_path.write_text("A,B\n", encoding="utf-8")
+
+    records = file_ops.load_csv(str(csv_path))
+
+    assert records == []
+
+
+def test_save_csv__sanitizes_when_enabled(tmp_path, patch_tqdm, monkeypatch):
+    records = [{"A": "=1+1"}]
+    output = tmp_path / "out.csv"
+
+    monkeypatch.setattr(file_ops, "sanitize_records", lambda _r: [{"A": "'=1+1"}])
+
+    file_ops.save_csv(records, str(output), sanitize=True)
+
+    content = output.read_text(encoding="utf-8-sig")
+    assert "'=1+1" in content
+
+
+def test_save_csv__empty_records_warns(tmp_path, patch_tqdm, caplog):
+    output = tmp_path / "out.csv"
+
+    with caplog.at_level("WARNING"):
+        file_ops.save_csv([], str(output), sanitize=True)
+
+    assert not output.exists()
+    assert "no records to save" in caplog.text.lower()
+
+
+def test_get_hash_map_from_folder__uses_compute(monkeypatch, tmp_path, patch_tqdm):
+    file_a = tmp_path / "a.txt"
+    file_a.write_text("a", encoding="utf-8")
+
+    monkeypatch.setattr(file_ops, "compute_file_hash", lambda _p: "hash")
+
+    result = file_ops.get_hash_map_from_folder(str(tmp_path), pattern="a.txt", recursive=False)
+
+    assert result[str(file_a)] == "hash"
+
+
+def test_unify_duplicate_files__renames_to_shortest(tmp_path, patch_tqdm, monkeypatch):
+    file_short = tmp_path / "a.txt"
+    file_long = tmp_path / "longname.txt"
+    file_short.write_text("data", encoding="utf-8")
+    file_long.write_text("data", encoding="utf-8")
+
+    monkeypatch.setattr(file_ops, "compute_file_hash", lambda _p: "hash")
+
+    file_ops.unify_duplicate_files(str(tmp_path), recursive=False)
+
+    assert (tmp_path / "a.txt").exists()
+    assert not file_long.exists()

--- a/exportpreparedmedia/tests/unit/test_shared_hash_utils__scenarios.py
+++ b/exportpreparedmedia/tests/unit/test_shared_hash_utils__scenarios.py
@@ -1,0 +1,37 @@
+"""
+Unit tests for exportpreparedmedia/shared/hash_utils.py.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+export_root = project_root / "exportpreparedmedia"
+sys.path.insert(0, str(export_root))
+
+import shared.hash_utils as hash_utils
+
+
+def test_compute_file_hash__md5_fallback(monkeypatch, tmp_path, caplog):
+    data_file = tmp_path / "data.bin"
+    data_file.write_bytes(b"abc")
+
+    monkeypatch.setattr(hash_utils, "XXHASH_AVAILABLE", False)
+    hash_utils._xxhash_warning_logged = False
+
+    with caplog.at_level("WARNING"):
+        result = hash_utils.compute_file_hash(str(data_file), method="xxhash64")
+
+    assert len(result) == 32
+    assert "falling back to md5" in caplog.text.lower()
+
+
+def test_compute_file_hash__sha256(tmp_path):
+    data_file = tmp_path / "data.bin"
+    data_file.write_bytes(b"abc")
+
+    result = hash_utils.compute_file_hash(str(data_file), method="sha256")
+
+    assert len(result) == 64

--- a/exportpreparedmedia/tests/unit/test_shared_logging_config__scenarios.py
+++ b/exportpreparedmedia/tests/unit/test_shared_logging_config__scenarios.py
@@ -1,0 +1,88 @@
+"""
+Unit tests for exportpreparedmedia/shared/logging_config.py.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+export_root = project_root / "exportpreparedmedia"
+sys.path.insert(0, str(export_root))
+
+import shared.logging_config as logging_config
+
+
+class DummyHandler:
+    def __init__(self, *_args, **_kwargs):
+        self.formatter = None
+
+    def setFormatter(self, formatter):
+        self.formatter = formatter
+
+
+class DummyLogger:
+    def __init__(self):
+        self.handlers = [DummyHandler()]
+        self.level = None
+
+    def setLevel(self, level):
+        self.level = level
+
+    def addHandler(self, handler):
+        self.handlers.append(handler)
+
+    def removeHandler(self, handler):
+        self.handlers.remove(handler)
+
+
+class DummyFormatter:
+    def __init__(self, *_args, **_kwargs):
+        return None
+
+
+def test_setup_logging__missing_config_raises(monkeypatch):
+    def fail_open(*_args, **_kwargs):
+        raise OSError("missing")
+
+    monkeypatch.setattr(logging_config, "open", fail_open)
+
+    with pytest.raises(Exception):
+        logging_config.setup_logging()
+
+
+def test_setup_logging__sets_level_and_handlers(monkeypatch):
+    dummy_logger = DummyLogger()
+
+    monkeypatch.setattr(logging_config.logging, "getLogger", lambda: dummy_logger)
+    monkeypatch.setattr(logging_config.logging, "StreamHandler", DummyHandler)
+    monkeypatch.setattr(logging_config.logging, "FileHandler", DummyHandler)
+    monkeypatch.setattr(logging_config.colorlog, "ColoredFormatter", DummyFormatter)
+
+    def fake_open(*_args, **_kwargs):
+        class DummyFile:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return '{"DEBUG": "white", "INFO": "green", "WARNING": "yellow", "ERROR": "red", "CRITICAL": "red"}'
+
+        return DummyFile()
+
+    monkeypatch.setattr(logging_config, "open", fake_open)
+    monkeypatch.setattr(logging_config.json, "load", lambda _f: {
+        "DEBUG": "white",
+        "INFO": "green",
+        "WARNING": "yellow",
+        "ERROR": "red",
+        "CRITICAL": "red",
+    })
+
+    logging_config.setup_logging(debug=False, log_file="C:/logs/test.log")
+
+    assert dummy_logger.level == logging_config.logging.INFO
+    assert len(dummy_logger.handlers) == 2

--- a/exportpreparedmedia/tests/unit/test_shared_media_filter__scenarios.py
+++ b/exportpreparedmedia/tests/unit/test_shared_media_filter__scenarios.py
@@ -1,0 +1,29 @@
+"""
+Unit tests for exportpreparedmedia/shared/media_filter.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+export_root = project_root / "exportpreparedmedia"
+sys.path.insert(0, str(export_root))
+
+from shared.media_filter import filter_prepared_items
+
+
+def test_filter_prepared_items__matches_status():
+    items = [
+        {"Status": "ready"},
+        {"Other": "x"},
+        {"status": "ready"},
+    ]
+
+    result = filter_prepared_items(items, "ready")
+
+    assert result == [items[0], items[2]]
+
+
+def test_filter_prepared_items__error_returns_empty():
+    result = filter_prepared_items(None, "ready")
+    assert result == []

--- a/exportpreparedmedia/tests/unit/test_shared_user_config__scenarios.py
+++ b/exportpreparedmedia/tests/unit/test_shared_user_config__scenarios.py
@@ -1,0 +1,53 @@
+"""
+Unit tests for exportpreparedmedia/shared/user_config.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+export_root = project_root / "exportpreparedmedia"
+sys.path.insert(0, str(export_root))
+
+import shared.user_config as user_config
+
+
+def test_user_config__env_overrides(monkeypatch):
+    monkeypatch.setattr(user_config, "_user_config_instance", None)
+    monkeypatch.setenv("PHOTOBANK_USERNAME", "env_user")
+
+    cfg = user_config.UserConfig()
+
+    assert cfg.get_username() == "env_user"
+
+
+def test_user_config__file_fallback(monkeypatch):
+    monkeypatch.setattr(user_config, "_user_config_instance", None)
+
+    class DummyConfig(user_config.UserConfig):
+        def _load_from_file(self):
+            return {"author": "File Author", "location": "File Town"}
+
+        def _load_from_environment(self):
+            return {}
+
+    cfg = DummyConfig()
+
+    assert cfg.get_author() == "File Author"
+    assert cfg.get_location() == "File Town"
+
+
+def test_user_config__is_configured(monkeypatch):
+    class DummyConfig(user_config.UserConfig):
+        def _load_from_file(self):
+            return {}
+
+        def _load_from_environment(self):
+            return {}
+
+        def _get_system_defaults(self):
+            return {"author": "Unknown Author", "location": "Unknown Location", "username": "u", "email": ""}
+
+    cfg = DummyConfig()
+
+    assert cfg.is_configured() is False

--- a/exportpreparedmedia/tests/unit/test_shared_utils__scenarios.py
+++ b/exportpreparedmedia/tests/unit/test_shared_utils__scenarios.py
@@ -1,0 +1,35 @@
+"""
+Unit tests for exportpreparedmedia/shared/utils.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+export_root = project_root / "exportpreparedmedia"
+sys.path.insert(0, str(export_root))
+
+import shared.utils as utils
+
+
+def test_get_script_name__basename(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["C:/tools/run_me.py"])
+    assert utils.get_script_name() == "run_me"
+
+
+def test_get_log_filename__format(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["C:/tools/run_me.py"])
+
+    class DummyDateTime:
+        @classmethod
+        def now(cls):
+            class Dummy:
+                def strftime(self, _fmt):
+                    return "2020-01-01_12-00-00"
+
+            return Dummy()
+
+    monkeypatch.setattr(utils, "datetime", DummyDateTime)
+
+    result = utils.get_log_filename("C:/logs")
+    assert result.endswith("run_me_Log_2020-01-01_12-00-00.log")

--- a/givephotobankreadymediafiles/givephotobankreadymediafileslib/batch_description_dialog.py
+++ b/givephotobankreadymediafiles/givephotobankreadymediafileslib/batch_description_dialog.py
@@ -157,9 +157,13 @@ class BatchDescriptionDialog:
         editorial_data = None
         if self.editorial_var.get():
             extracted, missing = extract_editorial_metadata_from_exif(self.file_path)
-            editorial_data = get_editorial_metadata(self.parent, missing, extracted)
-            if editorial_data is None:
-                return
+            if any(missing.values()):
+                editorial_data = get_editorial_metadata(self.parent, missing, extracted)
+                if editorial_data is None:
+                    return
+                editorial_data = {**extracted, **editorial_data}
+            else:
+                editorial_data = extracted
 
         self.result = {
             "action": "save",

--- a/givephotobankreadymediafiles/givephotobankreadymediafileslib/batch_prompts.py
+++ b/givephotobankreadymediafiles/givephotobankreadymediafileslib/batch_prompts.py
@@ -56,11 +56,11 @@ def build_batch_prompt(user_description: str, editorial_data: Optional[Dict[str,
             categories_block += ", ".join(dreamstime_cats) + "\n\n"
 
         categories_block += "IMPORTANT:\n"
-        categories_block += "- STRONGLY PREFER selecting the MAXIMUM number of categories when multiple relevant options exist\n"
-        categories_block += "- Make every effort to reach the maximum - consider broader or related categories if needed\n"
         categories_block += "- Choose categories that best match the image content and theme\n"
+        categories_block += "- If multiple categories are clearly relevant, select the maximum allowed\n"
+        categories_block += "- Never choose unrelated categories just to reach the maximum\n"
         categories_block += "- Categories MUST be based on VISUAL CONTENT, not word similarity (e.g., 'moth' photo ≠ 'Mothers Day')\n"
-        categories_block += "- Only select fewer than the maximum if truly no other relevant categories can be found\n\n"
+        categories_block += "- If only one category is truly appropriate, select only that one\n\n"
     else:
         # Fallback if no categories provided
         categories_block = (
@@ -68,11 +68,11 @@ def build_batch_prompt(user_description: str, editorial_data: Optional[Dict[str,
             "- shutterstock: Select UP TO 2 most appropriate categories\n"
             "- adobestock: Select UP TO 1 most appropriate category\n"
             "- dreamstime: Select UP TO 3 most appropriate categories\n"
-            "- STRONGLY PREFER selecting the MAXIMUM number when multiple relevant options exist\n"
-            "- Make every effort to reach the maximum - consider broader or related categories if needed\n"
             "- Choose categories that best match the image content and theme\n"
+            "- If multiple categories are clearly relevant, select the maximum allowed\n"
+            "- Never choose unrelated categories just to reach the maximum\n"
             "- Categories MUST be based on VISUAL CONTENT, not word similarity (e.g., 'moth' photo ≠ 'Mothers Day')\n"
-            "- Only select fewer than the maximum if truly no other relevant categories can be found\n\n"
+            "- If only one category is truly appropriate, select only that one\n\n"
         )
 
     return (

--- a/givephotobankreadymediafiles/shared/prompts_config.json
+++ b/givephotobankreadymediafiles/shared/prompts_config.json
@@ -128,7 +128,7 @@
       }
     },
     "categories": {
-      "template": "Select UP TO {max_categories} most appropriate categor{category_word} for this image from the {photobank} categories below (Attempt to reach the max though,but not at any cost).\n\nRequirements:\n- You may select 1-{max_categories} categories (you don't have to select the maximum)\n- Choose categories that best match the image content and theme\n- If only one category is truly appropriate, select only that one\n- Draw inspiration from existing successful stock photos or photos by user DannyJPN that have similar titles and descriptions\n\nAvailable categories:\n{categories_list}\n\n{title_section}{description_section}Return ONLY the selected category name{category_plural} separated by commas (1-{max_categories} categories), no other text.",
+      "template": "Select UP TO {max_categories} most appropriate categor{category_word} for this image from the {photobank} categories below.\n\nRequirements:\n- You may select 1-{max_categories} categories\n- Choose categories that best match the image content and theme\n- Select the maximum only when multiple options are clearly relevant\n- Never choose unrelated categories just to reach the maximum\n- If only one category is truly appropriate, select only that one\n\nAvailable categories:\n{categories_list}\n\n{title_section}{description_section}Return ONLY the selected category name{category_plural} separated by commas (1-{max_categories} categories), no other text.",
       "title_template": "Title: {title}\n",
       "description_template": "Description: {description}\n",
       "variables": {

--- a/givephotobankreadymediafiles/tests/__init__.py
+++ b/givephotobankreadymediafiles/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for givephotobankreadymediafiles."""

--- a/givephotobankreadymediafiles/tests/integration/test_metadata_generator_pipeline__scenarios.py
+++ b/givephotobankreadymediafiles/tests/integration/test_metadata_generator_pipeline__scenarios.py
@@ -1,0 +1,64 @@
+"""
+Integration tests for givephotobankreadymediafiles metadata generation pipeline.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+from shared.ai_provider import AIProvider, AIResponse, Message
+from givephotobankreadymediafileslib.metadata_generator import MetadataGenerator
+
+
+class DummyProvider(AIProvider):
+    def __init__(self, responses):
+        super().__init__("dummy")
+        self.responses = list(responses)
+
+    def generate_text(self, messages, **kwargs):
+        content = self.responses.pop(0)
+        return AIResponse(content=content, model=self.model_name)
+
+    def generate_text_stream(self, messages, **kwargs):
+        yield ""
+
+    def create_batch_job(self, messages_list, custom_ids, **kwargs):
+        raise NotImplementedError
+
+    def get_batch_job(self, job_id):
+        raise NotImplementedError
+
+    def cancel_batch_job(self, job_id):
+        return False
+
+    def supports_images(self):
+        return True
+
+
+def test_generate_all_metadata_pipeline(tmp_path):
+    image_path = tmp_path / "image.jpg"
+    image_path.write_bytes(b"\xff\xd8\xff")
+
+    responses = [
+        json.dumps({"original": "Calm lake at sunrise"}),  # title
+        json.dumps({"original": "A calm lake with warm sunrise tones."}),  # description
+        json.dumps({"original": ["lake", "sunrise", "reflection"]}),  # keywords
+        "Nature, Abstract",  # categories
+        "YES",  # editorial
+    ]
+    provider = DummyProvider(responses)
+
+    generator = MetadataGenerator(provider)
+    generator.set_photobank_categories({"Shutterstock": ["Nature", "Abstract", "Other"]})
+
+    metadata = generator.generate_all_metadata(str(image_path))
+
+    assert metadata.title.startswith("Calm lake")
+    assert "sunrise" in metadata.description.lower()
+    assert "lake" in metadata.keywords
+    assert metadata.categories["Shutterstock"][0] == "Nature"
+    assert metadata.editorial is True

--- a/givephotobankreadymediafiles/tests/performance/test_metadata_generator__keyword_parsing.py
+++ b/givephotobankreadymediafiles/tests/performance/test_metadata_generator__keyword_parsing.py
@@ -1,0 +1,40 @@
+"""
+Performance-oriented tests for metadata keyword parsing.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+from shared.ai_provider import AIProvider
+from givephotobankreadymediafileslib.metadata_generator import MetadataGenerator
+
+
+class DummyProvider(AIProvider):
+    def __init__(self):
+        super().__init__("dummy")
+
+    def generate_text(self, messages, **kwargs):
+        raise NotImplementedError
+
+    def generate_text_stream(self, messages, **kwargs):
+        yield ""
+
+    def create_batch_job(self, messages_list, custom_ids, **kwargs):
+        raise NotImplementedError
+
+    def get_batch_job(self, job_id):
+        raise NotImplementedError
+
+    def cancel_batch_job(self, job_id):
+        return False
+
+
+def test_parse_keywords_large_payload():
+    generator = MetadataGenerator(DummyProvider())
+    raw = ", ".join([f"keyword{i}" for i in range(500)])
+    keywords = generator._parse_keywords(raw)
+    assert len(keywords) == 500

--- a/givephotobankreadymediafiles/tests/security/test_metadata_generator__keyword_sanitization.py
+++ b/givephotobankreadymediafiles/tests/security/test_metadata_generator__keyword_sanitization.py
@@ -1,0 +1,43 @@
+"""
+Security-focused tests for keyword sanitization.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+from shared.ai_provider import AIProvider
+from givephotobankreadymediafileslib.metadata_generator import MetadataGenerator
+
+
+class DummyProvider(AIProvider):
+    def __init__(self):
+        super().__init__("dummy")
+
+    def generate_text(self, messages, **kwargs):
+        raise NotImplementedError
+
+    def generate_text_stream(self, messages, **kwargs):
+        yield ""
+
+    def create_batch_job(self, messages_list, custom_ids, **kwargs):
+        raise NotImplementedError
+
+    def get_batch_job(self, job_id):
+        raise NotImplementedError
+
+    def cancel_batch_job(self, job_id):
+        return False
+
+
+def test_validate_keyword_strips_scripts_and_symbols():
+    generator = MetadataGenerator(DummyProvider())
+    keyword = "<script>alert('x')</script> DROP; TABLE"
+    cleaned = generator._validate_keyword(keyword)
+    assert "<" not in cleaned
+    assert ">" not in cleaned
+    assert ";" not in cleaned
+    assert "DROP" in cleaned

--- a/givephotobankreadymediafiles/tests/unit/__init__.py
+++ b/givephotobankreadymediafiles/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for givephotobankreadymediafiles."""

--- a/givephotobankreadymediafiles/tests/unit/test_ai_coordinator__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_ai_coordinator__scenarios.py
@@ -1,0 +1,224 @@
+"""
+Unit tests for givephotobankreadymediafileslib/ai_coordinator.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+from givephotobankreadymediafileslib import ai_coordinator
+
+
+class DummyCombo:
+    def __init__(self, value=""):
+        self._value = value
+        self.values = None
+        self.current_index = None
+
+    def configure(self, values=None):
+        self.values = values
+
+    def set(self, value):
+        self._value = value
+
+    def get(self):
+        return self._value
+
+    def current(self, index):
+        self.current_index = index
+
+
+class DummyButton:
+    def __init__(self):
+        self.configs = []
+
+    def configure(self, **kwargs):
+        self.configs.append(kwargs)
+
+
+class DummyEntry:
+    def __init__(self, value=""):
+        self.value = value
+
+    def get(self):
+        return self.value
+
+    def delete(self, *_args):
+        self.value = ""
+
+    def insert(self, _index, value):
+        self.value = value
+
+
+class DummyText:
+    def __init__(self, value=""):
+        self.value = value
+
+    def get(self, *_args):
+        return self.value
+
+
+class DummyVar:
+    def __init__(self, value=False):
+        self.value = value
+
+    def get(self):
+        return self.value
+
+
+class DummyViewerState:
+    def __init__(self):
+        self.current_file_path = "C:/file.jpg"
+        self.title_entry = DummyEntry("old")
+        self.desc_text = DummyText("")
+        self.editorial_var = DummyVar(False)
+        self.keywords_list = []
+        self.title_changed = False
+
+    def on_title_change(self):
+        self.title_changed = True
+
+
+class DummyRoot:
+    def after(self, _ms, func, *args):
+        return func(*args)
+
+
+class DummyAIThread:
+    def __init__(self, alive=True):
+        self._alive = alive
+
+    def is_alive(self):
+        return self._alive
+
+
+def _build_coordinator(model_value="Model A"):
+    viewer_state = DummyViewerState()
+    ui = SimpleNamespace(
+        model_combo=DummyCombo(model_value),
+        title_generate_button=DummyButton(),
+        desc_generate_button=DummyButton(),
+        keywords_generate_button=DummyButton(),
+        categories_generate_button=DummyButton(),
+        generate_all_button=DummyButton(),
+    )
+    categories = SimpleNamespace(category_combos={})
+    return ai_coordinator.AICoordinator(DummyRoot(), viewer_state, categories, ui)
+
+
+def test_load_ai_models__no_models(monkeypatch):
+    coordinator = _build_coordinator()
+
+    class DummyConfig:
+        def get_available_ai_models(self):
+            return []
+
+    import shared.config as shared_config
+
+    monkeypatch.setattr(shared_config, "get_config", lambda: DummyConfig())
+    coordinator.load_ai_models()
+    assert coordinator.ui_components.model_combo.values == ["No models available"]
+
+
+def test_load_ai_models__default_selection(monkeypatch):
+    coordinator = _build_coordinator()
+
+    models = [
+        {"display_name": "Model A", "key": "p/a"},
+        {"display_name": "Model B", "key": "p/b"},
+    ]
+
+    class DummyConfig:
+        def get_available_ai_models(self):
+            return models
+
+        def get_default_ai_model(self):
+            return ("p", "b")
+
+    import shared.config as shared_config
+
+    monkeypatch.setattr(shared_config, "get_config", lambda: DummyConfig())
+    coordinator.load_ai_models()
+    assert coordinator.ui_components.model_combo.current_index == 1
+
+
+def test_get_current_ai_provider__invalid_model():
+    coordinator = _build_coordinator(model_value="No models available")
+    assert coordinator.get_current_ai_provider() is None
+
+
+def test_get_current_ai_provider__success(monkeypatch):
+    coordinator = _build_coordinator(model_value="Model A")
+
+    class DummyConfig:
+        def get_available_ai_models(self):
+            return [{"display_name": "Model A", "key": "p/a"}]
+
+    import shared.config as shared_config
+    import shared.ai_factory as ai_factory
+
+    monkeypatch.setattr(shared_config, "get_config", lambda: DummyConfig())
+    monkeypatch.setattr(ai_factory, "create_from_model_key", lambda _k: "provider")
+
+    assert coordinator.get_current_ai_provider() == "provider"
+
+
+def test_generate_title__no_file(monkeypatch):
+    coordinator = _build_coordinator()
+    coordinator.viewer_state.current_file_path = ""
+    called = []
+    monkeypatch.setattr(ai_coordinator.messagebox, "showwarning", lambda *_a, **_k: called.append(True))
+
+    coordinator.generate_title()
+    assert called
+
+
+def test_generate_title__invalid_model(monkeypatch):
+    coordinator = _build_coordinator(model_value="No models available")
+    called = []
+    monkeypatch.setattr(ai_coordinator.messagebox, "showwarning", lambda *_a, **_k: called.append(True))
+
+    coordinator.generate_title()
+    assert called
+
+
+def test_generate_title__cancel_running_thread(monkeypatch):
+    coordinator = _build_coordinator()
+    coordinator.ai_threads["title"] = DummyAIThread(alive=True)
+    coordinator._generate_all_active = False
+
+    coordinator.generate_title()
+    assert coordinator.ai_cancelled["title"] is True
+    assert coordinator.ai_threads["title"] is None
+
+
+def test_update_title_result__stale_generation(monkeypatch):
+    coordinator = _build_coordinator()
+    coordinator.current_generation_id["title"] = 2
+    coordinator._update_title_result("new", None, generation_id=1)
+    assert coordinator.viewer_state.title_entry.get() == "old"
+
+
+def test_update_title_result__error(monkeypatch):
+    coordinator = _build_coordinator()
+    coordinator.current_generation_id["title"] = 1
+    called = []
+    monkeypatch.setattr(ai_coordinator.messagebox, "showerror", lambda *_a, **_k: called.append(True))
+
+    coordinator._update_title_result(None, "boom", generation_id=1)
+    assert called
+
+
+def test_update_title_result__success(monkeypatch):
+    coordinator = _build_coordinator()
+    coordinator.current_generation_id["title"] = 1
+
+    coordinator._update_title_result("new title", None, generation_id=1)
+    assert coordinator.viewer_state.title_entry.get() == "new title"
+    assert coordinator.viewer_state.title_changed is True

--- a/givephotobankreadymediafiles/tests/unit/test_alternative_generator__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_alternative_generator__scenarios.py
@@ -1,0 +1,108 @@
+"""
+Unit tests for givephotobankreadymediafileslib/alternative_generator.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+from givephotobankreadymediafileslib import alternative_generator
+
+
+class DummyImage:
+    def __init__(self, mode="RGB"):
+        self.mode = mode
+        self.saved = []
+
+    def convert(self, _mode):
+        self.mode = _mode
+        return self
+
+    def save(self, path, _fmt=None, **_kwargs):
+        self.saved.append(path)
+
+    def filter(self, _filter):
+        return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+
+def test_generate_all_versions__missing_file(monkeypatch):
+    monkeypatch.setattr(alternative_generator.os.path, "exists", lambda _p: False)
+    generator = alternative_generator.AlternativeGenerator(enabled_alternatives=[], enabled_formats=[])
+
+    assert generator.generate_all_versions("C:/missing.jpg", "C:/out", "C:/edit") == []
+
+
+def test_generate_all_versions__unsupported_extension(monkeypatch):
+    monkeypatch.setattr(alternative_generator.os.path, "exists", lambda _p: True)
+    generator = alternative_generator.AlternativeGenerator(enabled_alternatives=[], enabled_formats=[])
+
+    assert generator.generate_all_versions("C:/file.txt", "C:/out", "C:/edit") == []
+
+
+def test_convert_format__success(monkeypatch):
+    dummy = DummyImage()
+    monkeypatch.setattr(alternative_generator.Image, "open", lambda _p: dummy)
+    generator = alternative_generator.AlternativeGenerator(enabled_alternatives=[], enabled_formats=[".png"])
+
+    ok = generator._convert_format("C:/file.jpg", "C:/out/file.png", ".png")
+    assert ok is True
+    assert dummy.saved
+
+
+def test_convert_format__unsupported_format(monkeypatch):
+    dummy = DummyImage()
+    monkeypatch.setattr(alternative_generator.Image, "open", lambda _p: dummy)
+    generator = alternative_generator.AlternativeGenerator(enabled_alternatives=[], enabled_formats=[".webp"])
+
+    ok = generator._convert_format("C:/file.jpg", "C:/out/file.webp", ".webp")
+    assert ok is False
+
+
+def test_generate_single_edit__missing_processor():
+    generator = alternative_generator.AlternativeGenerator(enabled_alternatives=[], enabled_formats=[])
+    result = generator._generate_single_edit("C:/file.jpg", "C:/out", "_unknown")
+    assert result is None
+
+
+def test_generate_edit_alternatives__unknown_tag_progress():
+    generator = alternative_generator.AlternativeGenerator(enabled_alternatives=["_unknown"], enabled_formats=[])
+
+    class DummyProgress:
+        def __init__(self):
+            self.count = 0
+
+        def update(self, value):
+            self.count += value
+
+    progress = DummyProgress()
+    result = generator._generate_edit_alternatives("C:/file.jpg", "C:/out", progress_bar=progress)
+
+    assert result == []
+    assert progress.count == 1
+
+
+def test_get_alternative_output_dirs__replaces_foto():
+    target_dir, edited_dir = alternative_generator.get_alternative_output_dirs(
+        "I:/Rozt/Foto/jpg/Abstrakty/DSC0001.JPG"
+    )
+
+    assert target_dir.endswith("Foto/jpg/Abstrakty")
+    assert "Upraven" in edited_dir
+
+
+def test_get_format_conversion_path__updates_extension():
+    path = alternative_generator.get_format_conversion_path(
+        "I:/Rozt/Foto/jpg/Abstrakty/DSC0001.JPG", ".png"
+    )
+    assert path.endswith("Foto/png/Abstrakty/DSC0001.png")

--- a/givephotobankreadymediafiles/tests/unit/test_batch_description_dialog__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_batch_description_dialog__scenarios.py
@@ -1,0 +1,168 @@
+"""
+Unit tests for givephotobankreadymediafileslib/batch_description_dialog.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+from givephotobankreadymediafileslib import batch_description_dialog
+
+
+class DummyText:
+    def __init__(self, value=""):
+        self.value = value
+
+    def get(self, *_args):
+        return self.value
+
+
+class DummyLabel:
+    def __init__(self):
+        self.text = None
+
+    def configure(self, **kwargs):
+        self.text = kwargs.get("text")
+
+
+class DummyButton:
+    def __init__(self):
+        self.states = []
+
+    def state(self, value):
+        self.states.append(value)
+
+
+class DummyVar:
+    def __init__(self, value=False):
+        self._value = value
+
+    def get(self):
+        return self._value
+
+
+class DummyParent:
+    def __init__(self):
+        self.destroyed = False
+
+    def destroy(self):
+        self.destroyed = True
+
+
+def _build_dialog(min_length=5, description="text", editorial=False):
+    dialog = batch_description_dialog.BatchDescriptionDialog.__new__(batch_description_dialog.BatchDescriptionDialog)
+    dialog.parent = DummyParent()
+    dialog.file_path = "C:/file.jpg"
+    dialog.min_length = min_length
+    dialog.progress_text = ""
+    dialog.saved_count = 0
+    dialog.batch_limit = 20
+    dialog.result = None
+    dialog.desc_text = DummyText(description)
+    dialog.counter_label = DummyLabel()
+    dialog.save_button = DummyButton()
+    dialog.editorial_var = DummyVar(editorial)
+    return dialog
+
+
+def test_update_counter__enables_when_length_ok():
+    dialog = _build_dialog(min_length=3, description="abcd")
+    dialog._update_counter()
+    assert ["!disabled"] in dialog.save_button.states
+
+
+def test_on_save__too_short(monkeypatch):
+    dialog = _build_dialog(min_length=10, description="short")
+    called = []
+    monkeypatch.setattr(batch_description_dialog.messagebox, "showwarning", lambda *_a, **_k: called.append(True))
+
+    dialog._on_save()
+    assert called
+    assert dialog.result is None
+
+
+def test_on_save__editorial_cancel(monkeypatch):
+    dialog = _build_dialog(min_length=1, description="long enough", editorial=True)
+    monkeypatch.setattr(batch_description_dialog, "extract_editorial_metadata_from_exif", lambda _p: ({}, {}))
+    monkeypatch.setattr(batch_description_dialog, "get_editorial_metadata", lambda *_a, **_k: None)
+
+    dialog._on_save()
+    assert dialog.result is None
+
+
+def test_on_save__success(monkeypatch):
+    dialog = _build_dialog(min_length=1, description="long enough", editorial=False)
+    monkeypatch.setattr(batch_description_dialog, "extract_editorial_metadata_from_exif", lambda _p: ({}, {}))
+
+    dialog._on_save()
+    assert dialog.result["action"] == "save"
+    assert dialog.parent.destroyed is True
+
+
+def test_on_reject__confirmation_false(monkeypatch):
+    dialog = _build_dialog()
+    monkeypatch.setattr(batch_description_dialog.messagebox, "askyesno", lambda *_a, **_k: False)
+
+    dialog._on_reject()
+    assert dialog.result is None
+
+
+def test_on_reject__confirmation_true(monkeypatch):
+    dialog = _build_dialog()
+    monkeypatch.setattr(batch_description_dialog.messagebox, "askyesno", lambda *_a, **_k: True)
+
+    dialog._on_reject()
+    assert dialog.result == {"action": "reject"}
+    assert dialog.parent.destroyed is True
+
+
+def test_on_skip_and_cancel():
+    dialog = _build_dialog()
+    dialog._on_skip()
+    assert dialog.result == {"action": "skip"}
+
+    dialog = _build_dialog()
+    dialog._on_cancel()
+    assert dialog.result == {"action": "skip"}
+
+
+def test_on_open_explorer__missing_file(monkeypatch):
+    dialog = _build_dialog()
+    monkeypatch.setattr(batch_description_dialog.os.path, "exists", lambda _p: False)
+    called = []
+    monkeypatch.setattr(batch_description_dialog.messagebox, "showwarning", lambda *_a, **_k: called.append(True))
+
+    dialog._on_open_explorer()
+    assert called
+
+
+def test_on_open_explorer__windows(monkeypatch):
+    dialog = _build_dialog()
+    monkeypatch.setattr(batch_description_dialog.os.path, "exists", lambda _p: True)
+    monkeypatch.setattr(batch_description_dialog.os, "name", "nt")
+    called = []
+    monkeypatch.setattr(batch_description_dialog.subprocess, "run", lambda cmd: called.append(cmd))
+
+    dialog._on_open_explorer()
+    assert called
+
+
+def test_collect_batch_description__returns_result(monkeypatch):
+    class DummyDialog:
+        def __init__(self, *_args, **_kwargs):
+            self.result = {"action": "save"}
+
+    class DummyRoot:
+        def mainloop(self):
+            return None
+
+    monkeypatch.setattr(batch_description_dialog.tk, "Tk", lambda: DummyRoot())
+    monkeypatch.setattr(batch_description_dialog, "BatchDescriptionDialog", DummyDialog)
+
+    result = batch_description_dialog.collect_batch_description("C:/file.jpg", 10)
+    assert result == {"action": "save"}

--- a/givephotobankreadymediafiles/tests/unit/test_batch_lock__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_batch_lock__scenarios.py
@@ -1,0 +1,109 @@
+"""
+Unit tests for givephotobankreadymediafileslib/batch_lock.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+from givephotobankreadymediafileslib import batch_lock
+
+
+class DummyHandle:
+    def __init__(self):
+        self.closed = False
+
+    def fileno(self):
+        return 123
+
+    def close(self):
+        self.closed = True
+
+
+def test_acquire_and_release__windows_locking(monkeypatch):
+    handle = DummyHandle()
+    calls = []
+
+    def fake_open(_path, _mode):
+        return handle
+
+    def fake_locking(_fd, op, _size):
+        calls.append(op)
+
+    monkeypatch.setattr(batch_lock, "open_file_handle", fake_open)
+    monkeypatch.setattr(batch_lock, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(batch_lock.os, "name", "nt")
+    monkeypatch.setattr(batch_lock, "msvcrt", SimpleNamespace(LK_NBLCK=1, LK_UNLCK=2, locking=fake_locking))
+
+    lock = batch_lock.BatchLock("C:/temp/batch.lock")
+    lock.acquire()
+    assert lock._locked is True
+    assert calls == [1]
+
+    lock.release()
+    assert lock._locked is False
+    assert handle.closed is True
+    assert calls == [1, 2]
+
+
+def test_acquire__double_acquire_raises(monkeypatch):
+    handle = DummyHandle()
+    monkeypatch.setattr(batch_lock, "open_file_handle", lambda _p, _m: handle)
+    monkeypatch.setattr(batch_lock, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(batch_lock.os, "name", "nt")
+    monkeypatch.setattr(batch_lock, "msvcrt", SimpleNamespace(LK_NBLCK=1, LK_UNLCK=2, locking=lambda *_: None))
+
+    lock = batch_lock.BatchLock("C:/temp/batch.lock")
+    lock.acquire()
+
+    try:
+        lock.acquire()
+    except RuntimeError as exc:
+        assert "already running" in str(exc)
+    else:
+        raise AssertionError("Expected RuntimeError for double acquire")
+
+
+def test_acquire__lock_failure_releases_handle(monkeypatch):
+    handle = DummyHandle()
+
+    def fake_locking(_fd, _op, _size):
+        raise OSError("busy")
+
+    monkeypatch.setattr(batch_lock, "open_file_handle", lambda _p, _m: handle)
+    monkeypatch.setattr(batch_lock, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(batch_lock.os, "name", "nt")
+    monkeypatch.setattr(batch_lock, "msvcrt", SimpleNamespace(LK_NBLCK=1, LK_UNLCK=2, locking=fake_locking))
+
+    lock = batch_lock.BatchLock("C:/temp/batch.lock")
+    try:
+        lock.acquire()
+    except RuntimeError as exc:
+        assert "lock unavailable" in str(exc)
+    else:
+        raise AssertionError("Expected RuntimeError on lock failure")
+
+    assert lock._locked is False
+    assert lock._handle is None
+    assert handle.closed is True
+
+
+def test_context_manager__acquires_and_releases(monkeypatch):
+    handle = DummyHandle()
+    monkeypatch.setattr(batch_lock, "open_file_handle", lambda _p, _m: handle)
+    monkeypatch.setattr(batch_lock, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(batch_lock.os, "name", "nt")
+    monkeypatch.setattr(batch_lock, "msvcrt", SimpleNamespace(LK_NBLCK=1, LK_UNLCK=2, locking=lambda *_: None))
+
+    lock = batch_lock.BatchLock("C:/temp/batch.lock")
+    with lock as acquired:
+        assert acquired is lock
+        assert lock._locked is True
+
+    assert lock._locked is False

--- a/givephotobankreadymediafiles/tests/unit/test_batch_manager__helpers.py
+++ b/givephotobankreadymediafiles/tests/unit/test_batch_manager__helpers.py
@@ -1,0 +1,218 @@
+"""
+Unit tests for helper functions in givephotobankreadymediafileslib/batch_manager.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+from givephotobankreadymediafileslib import batch_manager
+
+
+def test_get_default_model_key(monkeypatch):
+    class DummyConfig:
+        def get_default_ai_model(self):
+            return ("provider", "model")
+
+    monkeypatch.setattr(batch_manager, "get_config", lambda: DummyConfig())
+    assert batch_manager._get_default_model_key() == "provider/model"
+
+
+def test_create_batch_provider__missing_config(monkeypatch):
+    class DummyConfig:
+        def get_ai_model_config(self, *_args):
+            return None
+
+    monkeypatch.setattr(batch_manager, "get_config", lambda: DummyConfig())
+    try:
+        batch_manager._create_batch_provider("p/m")
+    except RuntimeError as exc:
+        assert "No valid AI model" in str(exc)
+    else:
+        raise AssertionError("Expected RuntimeError")
+
+
+def test_create_batch_provider__supports(monkeypatch):
+    class DummyProvider:
+        def supports_batch(self):
+            return True
+
+        def supports_images(self):
+            return True
+
+    class DummyConfig:
+        def get_ai_model_config(self, *_args):
+            return {"api_key": "key"}
+
+    monkeypatch.setattr(batch_manager, "get_config", lambda: DummyConfig())
+    monkeypatch.setattr(batch_manager, "create_from_model_key", lambda *_a, **_k: DummyProvider())
+
+    provider = batch_manager._create_batch_provider("p/m")
+    assert isinstance(provider, DummyProvider)
+
+
+def test_estimate_prompt_tokens__uses_tiktoken(monkeypatch):
+    class DummyEncoding:
+        def encode(self, text):
+            return list(text)
+
+    class DummyToken:
+        def get_encoding(self, _name):
+            return DummyEncoding()
+
+    monkeypatch.setitem(sys.modules, "tiktoken", DummyToken())
+    assert batch_manager._estimate_prompt_tokens("abc") == 3
+
+
+def test_estimate_vision_tokens__zero():
+    assert batch_manager._estimate_vision_tokens(0, 100) == 0
+
+
+def test_sanitize_text__strips_and_replaces():
+    value = " a{b}\n c\r "
+    assert batch_manager._sanitize_text(value) == "a(b) c"
+
+
+def test_classify_send_error__message_fallback():
+    assert batch_manager._classify_send_error(RuntimeError("rate limit")) == "rate_limit"
+    assert batch_manager._classify_send_error(RuntimeError("auth failed")) == "auth"
+    assert batch_manager._classify_send_error(RuntimeError("timeout")) == "network"
+
+
+def test_get_openai_daily_count(monkeypatch):
+    date_key = "2024-01-01"
+    ts = int(datetime(2024, 1, 1, 12, 0).timestamp())
+
+    class DummyBatch:
+        def __init__(self, created_at):
+            self.created_at = created_at
+
+    class DummyBatches:
+        def list(self, limit=200):
+            return SimpleNamespace(data=[DummyBatch(ts), DummyBatch(ts)])
+
+    class DummyClient:
+        batches = DummyBatches()
+
+    class DummyProvider:
+        def _get_client(self):
+            return DummyClient()
+
+    assert batch_manager._get_openai_daily_count(DummyProvider(), date_key) == 2
+
+
+def test_build_messages__missing_file(monkeypatch):
+    monkeypatch.setattr(batch_manager.os.path, "exists", lambda _p: False)
+    assert batch_manager._build_messages("C:/missing.jpg", "desc", None) is None
+
+
+def test_build_messages__success(monkeypatch):
+    monkeypatch.setattr(batch_manager.os.path, "exists", lambda _p: True)
+    monkeypatch.setattr(batch_manager, "_image_to_content_block", lambda _p: "content")
+    monkeypatch.setattr(batch_manager, "build_batch_prompt", lambda *_a, **_k: "prompt")
+
+    class DummyMessage:
+        @staticmethod
+        def user(content):
+            return ("user", content)
+
+    class DummyContentBlock:
+        @staticmethod
+        def text(text):
+            return ("text", text)
+
+    monkeypatch.setattr(batch_manager, "Message", DummyMessage)
+    monkeypatch.setattr(batch_manager, "ContentBlock", DummyContentBlock)
+
+    messages = batch_manager._build_messages("C:/file.jpg", "desc", None)
+    assert messages == [("user", [("text", "prompt"), "content"])]
+
+
+def test_find_record_for_path():
+    records = [
+        {batch_manager.COL_PATH: "C:/a.jpg"},
+        {batch_manager.COL_PATH: "C:/b.jpg"},
+    ]
+    found = batch_manager._find_record_for_path(records, "C:\\b.jpg")
+    assert found == records[1]
+
+
+def test_normalize_path():
+    assert "\\" not in batch_manager._normalize_path("C:\\a.jpg")
+
+
+def test_build_custom_id():
+    assert batch_manager._build_custom_id("C:/path/file.jpg", "batch1") == "file_batch1"
+
+
+def test_parse_keywords__list_and_string():
+    assert batch_manager._parse_keywords(["a", ""]) == ["a"]
+    assert batch_manager._parse_keywords("a, b") == ["a", "b"]
+
+
+def test_get_default_effects(monkeypatch):
+    monkeypatch.setattr(batch_manager, "DEFAULT_ALTERNATIVE_EFFECTS", "bw,negative")
+    monkeypatch.setattr(batch_manager, "EFFECT_NAME_MAPPING", {"bw": "_bw"})
+    assert batch_manager._get_default_effects() == ["_bw", "negative"]
+
+
+def test_find_or_create_alternative_batch(monkeypatch):
+    class DummyRegistry:
+        def __init__(self):
+            self.created = False
+
+        def get_active_batches(self, status=None):
+            return {"batch_1": {"batch_type": "alternatives_bw"}} if status == "collecting" else {}
+
+        def create_batch(self, batch_type, _size):
+            self.created = True
+            return "batch_new"
+
+    registry = DummyRegistry()
+    assert batch_manager._find_or_create_alternative_batch(registry, "_bw") == "batch_1"
+
+    registry = DummyRegistry()
+    registry.get_active_batches = lambda status=None: {}
+    assert batch_manager._find_or_create_alternative_batch(registry, "_bw") == "batch_new"
+    assert registry.created is True
+
+
+def test_update_record_with_metadata__status_and_categories():
+    record = {
+        "ShutterStock status": batch_manager.STATUS_UNPROCESSED,
+        "ShutterStock kategorie": "",
+    }
+    metadata = {
+        "title": "Title",
+        "description": "Desc",
+        "keywords": ["one", "two"],
+        "categories": {"ShutterStock": ["Nature"]},
+    }
+
+    batch_manager._update_record_with_metadata(record, metadata)
+    assert record["ShutterStock status"] == batch_manager.STATUS_PREPARED
+    assert "Nature" in record["ShutterStock kategorie"]
+
+
+def test_reject_record__sets_status():
+    record = {"Bank status": batch_manager.STATUS_UNPROCESSED}
+    batch_manager._reject_record(record)
+    assert record["Bank status"] == batch_manager.STATUS_REJECTED
+
+
+def test_save_metadata_to_csv__writes(monkeypatch):
+    records = [{batch_manager.COL_PATH: "C:/file.jpg", "Bank status": batch_manager.STATUS_UNPROCESSED}]
+    monkeypatch.setattr(batch_manager, "load_csv", lambda _p: records)
+    called = []
+    monkeypatch.setattr(batch_manager, "save_csv_with_backup", lambda _r, _p: called.append(True))
+
+    result = batch_manager._save_metadata_to_csv("media.csv", "C:/file.jpg", {"title": "t"}, False)
+    assert result is True
+    assert called

--- a/givephotobankreadymediafiles/tests/unit/test_batch_prompts__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_batch_prompts__scenarios.py
@@ -1,0 +1,80 @@
+"""
+Unit tests for givephotobankreadymediafileslib/batch_prompts.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+from givephotobankreadymediafileslib import batch_prompts
+
+
+def test_build_batch_prompt__includes_editorial_block():
+    prompt = batch_prompts.build_batch_prompt(
+        "User desc",
+        editorial_data={"city": "Prague", "country": "Czechia", "date": "01 01 2025"},
+        categories=None,
+    )
+
+    assert "EDITORIAL REQUIREMENT" in prompt
+    assert "PRAGUE, CZECHIA - 01 01 2025" in prompt
+
+
+def test_build_batch_prompt__fallback_categories_block():
+    prompt = batch_prompts.build_batch_prompt("Desc", editorial_data=None, categories=None)
+
+    assert "CATEGORIES REQUIREMENTS" in prompt
+    assert "- shutterstock: Select UP TO 2" in prompt
+    assert "- dreamstime: Select UP TO 3" in prompt
+
+
+def test_build_batch_prompt__custom_categories_block():
+    prompt = batch_prompts.build_batch_prompt(
+        "Desc",
+        editorial_data=None,
+        categories={
+            "ShutterStock": ["Nature", "People"],
+            "AdobeStock": ["Travel"],
+            "Dreamstime": ["Food", "Sports"],
+        },
+    )
+
+    assert "SHUTTERSTOCK" in prompt
+    assert "Nature, People" in prompt
+    assert "ADOBESTOCK" in prompt
+    assert "Travel" in prompt
+    assert "DREAMSTIME" in prompt
+    assert "Food, Sports" in prompt
+
+
+def test_build_alternative_prompt__known_tag():
+    prompt = batch_prompts.build_alternative_prompt(
+        "_bw",
+        original_title="Title",
+        original_description="Desc",
+        original_keywords=["one", "two"],
+        editorial=True,
+    )
+
+    assert "black and white" in prompt
+    assert "This is editorial content." in prompt
+    assert "keywords: one, two" in prompt.lower()
+
+
+def test_build_alternative_prompt__unknown_tag():
+    prompt = batch_prompts.build_alternative_prompt(
+        "_custom",
+        original_title="Title",
+        original_description="Desc",
+        original_keywords=["one"] * 12,
+        editorial=False,
+    )
+
+    assert "This is commercial content." in prompt
+    assert "Edit-specific instructions for _custom" in prompt
+    assert "... (12 total)" in prompt

--- a/givephotobankreadymediafiles/tests/unit/test_batch_state__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_batch_state__scenarios.py
@@ -1,0 +1,112 @@
+"""
+Unit tests for givephotobankreadymediafileslib/batch_state.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+from givephotobankreadymediafileslib import batch_state
+
+
+def test__utcnow_iso__returns_iso_format():
+    value = batch_state._utcnow_iso()
+    assert "T" in value
+    assert value.count(":") >= 2
+
+
+def test__normalize_path__uses_forward_slashes():
+    normalized = batch_state._normalize_path(r"C:\Temp\file.jpg")
+    assert "\\" not in normalized
+
+
+def test_batch_registry__create_and_update(tmp_path, monkeypatch):
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setattr(batch_state, "BATCH_STATE_DIR", str(tmp_path / "batch_state"))
+
+    registry = batch_state.BatchRegistry(registry_path=str(registry_path))
+    batch_id = registry.create_batch("originals", batch_size_limit=5)
+
+    assert batch_id in registry.data["active_batches"]
+    registry.increment_batch_file_count(batch_id)
+    assert registry.data["active_batches"][batch_id]["file_count"] == 1
+
+    registry.set_batch_status(batch_id, "ready", openai_batch_id="abc")
+    assert registry.data["active_batches"][batch_id]["status"] == "ready"
+    assert registry.data["active_batches"][batch_id]["openai_batch_id"] == "abc"
+
+
+def test_batch_registry__register_and_complete(tmp_path, monkeypatch):
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setattr(batch_state, "BATCH_STATE_DIR", str(tmp_path / "batch_state"))
+
+    registry = batch_state.BatchRegistry(registry_path=str(registry_path))
+    batch_id = registry.create_batch("originals", batch_size_limit=5)
+
+    registry.register_file("C:/files/a.jpg", batch_id)
+    assert registry.data["file_registry"]
+
+    registry.complete_batch(batch_id)
+    assert batch_id not in registry.data["active_batches"]
+    assert registry.data["file_registry"] == {}
+
+
+def test_batch_registry__register_file_conflict(tmp_path):
+    registry = batch_state.BatchRegistry(registry_path=str(tmp_path / "registry.json"))
+    registry.data["file_registry"] = {"C:/files/a.jpg": "batch_1"}
+
+    try:
+        registry.register_file("C:/files/a.jpg", "batch_2")
+    except ValueError as exc:
+        assert "already in active batch" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for conflicting file registration")
+
+
+def test_batch_registry__cleanup_completed(tmp_path, monkeypatch):
+    registry_path = tmp_path / "registry.json"
+    monkeypatch.setattr(batch_state, "BATCH_STATE_DIR", str(tmp_path / "batch_state"))
+
+    registry = batch_state.BatchRegistry(registry_path=str(registry_path))
+    registry.data["completed_batches"] = [
+        {"batch_id": "batch_old", "completed_at": "2000-01-01T00:00:00"},
+        {"batch_id": "batch_new", "completed_at": "2999-01-01T00:00:00"},
+        {"batch_id": "batch_bad", "completed_at": "not-a-date"},
+    ]
+
+    deleted = []
+
+    def fake_delete(path):
+        deleted.append(path)
+
+    import shared.file_operations as file_operations
+
+    monkeypatch.setattr(batch_state.os.path, "exists", lambda _p: True)
+    monkeypatch.setattr(file_operations, "delete_folder", fake_delete)
+
+    registry.cleanup_completed(cleanup_days=1)
+    assert any("batch_old" in path for path in deleted)
+    assert any(item["batch_id"] == "batch_new" for item in registry.data["completed_batches"])
+    assert any(item["batch_id"] == "batch_bad" for item in registry.data["completed_batches"])
+
+
+def test_batch_state__add_and_update(tmp_path):
+    batch_dir = tmp_path / "batch_1"
+    state = batch_state.BatchState("batch_1", str(batch_dir))
+
+    state.add_file("C:/files/a.jpg", "custom_1", user_description="desc", editorial=True)
+    assert state.state["files"]
+
+    state.update_file("C:/files/a.jpg", status="done")
+    assert state.state["files"][0]["status"] == "done"
+
+    state.update_file_by_custom_id("custom_1", error="oops")
+    assert state.state["files"][0]["error"] == "oops"
+
+    assert state.list_by_status("done")
+    assert state.all_files()

--- a/givephotobankreadymediafiles/tests/unit/test_categories_manager__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_categories_manager__scenarios.py
@@ -1,0 +1,92 @@
+"""
+Unit tests for givephotobankreadymediafileslib/categories_manager.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+from givephotobankreadymediafileslib import categories_manager
+
+
+class DummyFrame:
+    def __init__(self, *_args, **_kwargs):
+        self.packed = False
+
+    def pack(self, *_args, **_kwargs):
+        self.packed = True
+
+
+class DummyLabel:
+    def __init__(self, *_args, **_kwargs):
+        self.text = _kwargs.get("text", "")
+
+    def pack(self, *_args, **_kwargs):
+        return None
+
+
+class DummyCombobox:
+    def __init__(self, *_args, **kwargs):
+        self._values = kwargs.get("values", [])
+        self._value = ""
+
+    def pack(self, *_args, **_kwargs):
+        return None
+
+    def set(self, value):
+        self._value = value
+
+    def get(self):
+        return self._value
+
+    def __getitem__(self, key):
+        if key == "values":
+            return self._values
+        raise KeyError(key)
+
+
+class DummyTtk:
+    Frame = DummyFrame
+    Label = DummyLabel
+    Combobox = DummyCombobox
+
+
+def test_populate_categories_ui__no_container(monkeypatch):
+    monkeypatch.setattr(categories_manager, "ttk", DummyTtk)
+    manager = categories_manager.CategoriesManager(root=object(), categories={"ShutterStock": ["A"]})
+
+    manager.populate_categories_ui()
+    assert manager.category_combos == {}
+
+
+def test_populate_categories_ui__creates_dropdowns(monkeypatch):
+    monkeypatch.setattr(categories_manager, "ttk", DummyTtk)
+    manager = categories_manager.CategoriesManager(root=object(), categories={"ShutterStock": ["A", "B"]})
+    manager.categories_container = DummyFrame()
+
+    manager.populate_categories_ui()
+
+    assert "ShutterStock" in manager.category_combos
+    assert len(manager.category_combos["ShutterStock"]) == 2
+
+
+def test_load_collect_update_categories(monkeypatch):
+    monkeypatch.setattr(categories_manager, "ttk", DummyTtk)
+    manager = categories_manager.CategoriesManager(root=object(), categories={"ShutterStock": ["A", "B"]})
+    manager.categories_container = DummyFrame()
+    manager.populate_categories_ui()
+
+    record = {"ShutterStock kategorie": "A, B"}
+    manager.load_existing_categories(record)
+
+    selected = manager.collect_selected_categories()
+    assert selected["ShutterStock"] == ["A", "B"]
+
+    manager.update_categories({"ShutterStock": ["B"]})
+    selected_after = manager.collect_selected_categories()
+    assert selected_after["ShutterStock"][0] == "B"

--- a/givephotobankreadymediafiles/tests/unit/test_constants__sanity.py
+++ b/givephotobankreadymediafiles/tests/unit/test_constants__sanity.py
@@ -1,0 +1,27 @@
+"""
+Sanity tests for givephotobankreadymediafileslib/constants.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+from givephotobankreadymediafileslib import constants
+
+
+def test_get_status_column__suffix():
+    assert constants.get_status_column("Adobe") == "Adobe status"
+
+
+def test_get_category_column__suffix():
+    assert constants.get_category_column("Shutter") == "Shutter kategorie"
+
+
+def test_default_batch_limits__sane_ranges():
+    assert constants.BATCH_SIZE_MIN < constants.BATCH_SIZE_MAX
+    assert constants.DEFAULT_BATCH_SIZE >= constants.BATCH_SIZE_MIN

--- a/givephotobankreadymediafiles/tests/unit/test_csv_sanitizer__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_csv_sanitizer__scenarios.py
@@ -1,0 +1,73 @@
+"""
+Unit tests for givephotobankreadymediafiles/shared/csv_sanitizer.py.
+"""
+
+import sys
+from pathlib import Path
+import pytest
+
+project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+from shared.csv_sanitizer import sanitize_field, sanitize_record, sanitize_records, is_dangerous
+
+
+class TestSanitizeField:
+    def test_normal_text_unchanged(self):
+        value = "Normal text"
+        assert sanitize_field(value) == value
+        assert not is_dangerous(value)
+
+    def test_none_and_empty(self):
+        assert sanitize_field(None) == ""
+        assert sanitize_field("") == ""
+        assert sanitize_field("   ") == ""
+
+    def test_non_string(self):
+        assert sanitize_field(123) == "123"
+
+    @pytest.mark.parametrize("value", ["=1+1", "+SUM(1+1)", "-1+1", "@SUM(1)"])
+    def test_dangerous_prefixes(self, value):
+        assert sanitize_field(value).startswith("'")
+        assert is_dangerous(value)
+
+    @pytest.mark.parametrize("value", ["\tTAB", "\nNL", "\rCR"])
+    def test_control_prefixes(self, value):
+        assert sanitize_field(value).startswith("'")
+        assert is_dangerous(value)
+
+    def test_suspicious_patterns(self):
+        values = ["cmd|'/c calc'", "file:///c:/windows", "\\\\server\\share"]
+        for v in values:
+            assert sanitize_field(v).startswith("'")
+            assert is_dangerous(v)
+
+    def test_leading_single_quote_not_doubled(self):
+        value = "'=SUM(1+1)"
+        assert sanitize_field(value) == "'=SUM(1+1)"
+
+    def test_legit_url_not_sanitized(self):
+        value = "https://example.com/path"
+        assert sanitize_field(value) == value
+
+    def test_hyphen_mid_text_not_sanitized(self):
+        value = "High-quality photo (2024)"
+        assert sanitize_field(value) == value
+        assert not is_dangerous(value)
+
+
+class TestSanitizeRecords:
+    def test_sanitize_record(self):
+        record = {"name": "=cmd|calc", "desc": "Normal"}
+        result = sanitize_record(record)
+        assert result["name"].startswith("'")
+        assert result["desc"] == "Normal"
+
+    def test_sanitize_records_list(self):
+        records = [{"a": "=1"}, {"a": "ok"}]
+        result = sanitize_records(records)
+        assert result[0]["a"].startswith("'")
+        assert result[1]["a"] == "ok"
+
+    def test_empty_records(self):
+        assert sanitize_records([]) == []

--- a/givephotobankreadymediafiles/tests/unit/test_editorial_dialog__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_editorial_dialog__scenarios.py
@@ -1,0 +1,133 @@
+"""
+Unit tests for givephotobankreadymediafileslib/editorial_dialog.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+from givephotobankreadymediafileslib import editorial_dialog
+
+
+class DummyEntry:
+    def __init__(self, value=""):
+        self._value = value
+        self.focused = False
+
+    def get(self):
+        return self._value
+
+    def focus(self):
+        self.focused = True
+
+
+class DummyDialog:
+    def __init__(self):
+        self.destroyed = False
+
+    def destroy(self):
+        self.destroyed = True
+
+
+def test_validate_date_format__valid_and_invalid():
+    dialog = editorial_dialog.EditorialMetadataDialog.__new__(editorial_dialog.EditorialMetadataDialog)
+
+    assert dialog.validate_date_format("15 03 2024") is True
+    assert dialog.validate_date_format("32 01 2024") is False
+    assert dialog.validate_date_format("15-03-2024") is False
+
+
+def test_on_ok__missing_field(monkeypatch):
+    dialog = editorial_dialog.EditorialMetadataDialog.__new__(editorial_dialog.EditorialMetadataDialog)
+    dialog.entries = {"city": DummyEntry("")}
+    dialog.dialog = DummyDialog()
+    dialog.result = None
+
+    called = []
+    monkeypatch.setattr(editorial_dialog.messagebox, "showerror", lambda *_a, **_k: called.append(True))
+
+    dialog.on_ok()
+    assert called
+    assert dialog.result is None
+
+
+def test_on_ok__invalid_date(monkeypatch):
+    dialog = editorial_dialog.EditorialMetadataDialog.__new__(editorial_dialog.EditorialMetadataDialog)
+    dialog.entries = {"date": DummyEntry("99 99 2024")}
+    dialog.dialog = DummyDialog()
+    dialog.result = None
+
+    called = []
+    monkeypatch.setattr(editorial_dialog.messagebox, "showerror", lambda *_a, **_k: called.append(True))
+
+    dialog.on_ok()
+    assert called
+    assert dialog.result is None
+
+
+def test_on_ok__success():
+    dialog = editorial_dialog.EditorialMetadataDialog.__new__(editorial_dialog.EditorialMetadataDialog)
+    dialog.entries = {"city": DummyEntry("Prague")}
+    dialog.dialog = DummyDialog()
+    dialog.result = None
+
+    dialog.on_ok()
+    assert dialog.result == {"city": "Prague"}
+    assert dialog.dialog.destroyed is True
+
+
+def test_get_editorial_metadata__delegates(monkeypatch):
+    class Dummy:
+        def __init__(self, *_a, **_k):
+            return None
+
+        def show_and_get_result(self):
+            return {"city": "Prague"}
+
+    monkeypatch.setattr(editorial_dialog, "EditorialMetadataDialog", Dummy)
+    result = editorial_dialog.get_editorial_metadata(object(), {"city": True})
+    assert result == {"city": "Prague"}
+
+
+def test_format_editorial_prefix__uppercase():
+    result = editorial_dialog.format_editorial_prefix("Prague", "Czechia", "01 01 2024")
+    assert result == "PRAGUE, CZECHIA - 01 01 2024:"
+
+
+def test_extract_editorial_metadata_from_exif__with_date(monkeypatch):
+    class DummyImage:
+        def _getexif(self):
+            return {306: "2024:01:02 10:11:12"}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+    import PIL.Image as pil_image
+    import PIL.ExifTags as pil_exif_tags
+
+    monkeypatch.setattr(pil_image, "open", lambda _p: DummyImage())
+    monkeypatch.setattr(pil_exif_tags, "TAGS", {306: "DateTime"})
+
+    data, missing = editorial_dialog.extract_editorial_metadata_from_exif("C:/file.jpg")
+    assert data["date"] == "02 01 2024"
+    assert missing["date"] is False
+
+
+def test_extract_editorial_metadata_from_exif__exception(monkeypatch):
+    def raise_error(_p):
+        raise OSError("bad file")
+
+    import PIL.Image as pil_image
+
+    monkeypatch.setattr(pil_image, "open", raise_error)
+    data, missing = editorial_dialog.extract_editorial_metadata_from_exif("C:/file.jpg")
+    assert data == {}
+    assert all(missing.values())

--- a/givephotobankreadymediafiles/tests/unit/test_generatealternatives__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_generatealternatives__scenarios.py
@@ -1,0 +1,86 @@
+"""
+Unit tests for givephotobankreadymediafiles/generatealternatives.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+import generatealternatives as script
+
+
+def test_parse_comma_separated():
+    assert script.parse_comma_separated("a, b") == ["a", "b"]
+    assert script.parse_comma_separated("") == []
+
+
+def test_map_user_effects_to_tags__unknown():
+    try:
+        script.map_user_effects_to_tags(["unknown"])
+    except ValueError as exc:
+        assert "Unknown effect" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError")
+
+
+def test_map_user_formats_to_extensions__unknown():
+    try:
+        script.map_user_formats_to_extensions(["weird"])
+    except ValueError as exc:
+        assert "Unknown format" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError")
+
+
+def test_validate_file__missing(monkeypatch):
+    monkeypatch.setattr(script.os.path, "exists", lambda _p: False)
+    assert script.validate_file("C:/missing.jpg") is False
+
+
+def test_validate_file__unsupported(monkeypatch):
+    monkeypatch.setattr(script.os.path, "exists", lambda _p: True)
+    assert script.validate_file("C:/file.txt") is False
+
+
+def test_main__validation_failure(monkeypatch):
+    args = SimpleNamespace(
+        file="C:/file.jpg",
+        log_dir="logs",
+        debug=False,
+        formats="png",
+        effects="bw",
+        formats_only=False,
+        effects_only=False,
+    )
+
+    monkeypatch.setattr(script, "parse_arguments", lambda: args)
+    monkeypatch.setattr(script, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(script, "setup_logging", lambda **_k: None)
+    monkeypatch.setattr(script, "validate_file", lambda _p: False)
+
+    assert script.main() == 1
+
+
+def test_main__nothing_to_generate(monkeypatch):
+    args = SimpleNamespace(
+        file="C:/file.jpg",
+        log_dir="logs",
+        debug=False,
+        formats="",
+        effects="",
+        formats_only=False,
+        effects_only=False,
+    )
+
+    monkeypatch.setattr(script, "parse_arguments", lambda: args)
+    monkeypatch.setattr(script, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(script, "setup_logging", lambda **_k: None)
+    monkeypatch.setattr(script, "validate_file", lambda _p: True)
+
+    assert script.main() == 1

--- a/givephotobankreadymediafiles/tests/unit/test_givephotobankreadymediafiles__main__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_givephotobankreadymediafiles__main__scenarios.py
@@ -1,0 +1,149 @@
+"""
+Unit tests for givephotobankreadymediafiles/givephotobankreadymediafiles.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+import givephotobankreadymediafiles as main_module
+
+
+def test_main__check_batch_status(monkeypatch):
+    args = SimpleNamespace(
+        media_csv="media.csv",
+        categories_csv="cats.csv",
+        log_dir="logs",
+        debug=False,
+        max_count=1,
+        interval=0,
+        batch_mode=False,
+        batch_size=1,
+        batch_wait_timeout=0,
+        batch_poll_interval=0,
+        check_batch_status=True,
+    )
+
+    monkeypatch.setattr(main_module, "parse_arguments", lambda: args)
+    monkeypatch.setattr(main_module, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(main_module, "setup_logging", lambda **_k: None)
+    monkeypatch.setattr(main_module, "get_config", lambda: object())
+    monkeypatch.setattr(main_module, "check_batch_statuses", lambda: ["ok"])
+
+    assert main_module.main() == 0
+
+
+def test_main__batch_mode_lock_failure(monkeypatch):
+    args = SimpleNamespace(
+        media_csv="media.csv",
+        categories_csv="cats.csv",
+        log_dir="logs",
+        debug=False,
+        max_count=1,
+        interval=0,
+        batch_mode=True,
+        batch_size=1,
+        batch_wait_timeout=0,
+        batch_poll_interval=0,
+        check_batch_status=False,
+    )
+
+    monkeypatch.setattr(main_module, "parse_arguments", lambda: args)
+    monkeypatch.setattr(main_module, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(main_module, "setup_logging", lambda **_k: None)
+    monkeypatch.setattr(main_module, "get_config", lambda: object())
+
+    class DummyLock:
+        def __init__(self, _p):
+            return None
+
+        def acquire(self):
+            raise RuntimeError("locked")
+
+    monkeypatch.setattr(main_module, "BatchLock", DummyLock)
+    assert main_module.main() == 1
+
+
+def test_main__no_media_records(monkeypatch):
+    args = SimpleNamespace(
+        media_csv="media.csv",
+        categories_csv="cats.csv",
+        log_dir="logs",
+        debug=False,
+        max_count=1,
+        interval=0,
+        batch_mode=False,
+        batch_size=1,
+        batch_wait_timeout=0,
+        batch_poll_interval=0,
+        check_batch_status=False,
+    )
+
+    monkeypatch.setattr(main_module, "parse_arguments", lambda: args)
+    monkeypatch.setattr(main_module, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(main_module, "setup_logging", lambda **_k: None)
+    monkeypatch.setattr(main_module, "get_config", lambda: object())
+    monkeypatch.setattr(main_module, "load_media_records", lambda _p: [])
+
+    assert main_module.main() == 1
+
+
+def test_main__no_unprocessed(monkeypatch):
+    args = SimpleNamespace(
+        media_csv="media.csv",
+        categories_csv="cats.csv",
+        log_dir="logs",
+        debug=False,
+        max_count=1,
+        interval=0,
+        batch_mode=False,
+        batch_size=1,
+        batch_wait_timeout=0,
+        batch_poll_interval=0,
+        check_batch_status=False,
+    )
+
+    monkeypatch.setattr(main_module, "parse_arguments", lambda: args)
+    monkeypatch.setattr(main_module, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(main_module, "setup_logging", lambda **_k: None)
+    monkeypatch.setattr(main_module, "get_config", lambda: object())
+    monkeypatch.setattr(main_module, "load_media_records", lambda _p: [{"Cesta": "C:/file.jpg"}])
+    monkeypatch.setattr(main_module, "load_categories", lambda _p: {})
+    monkeypatch.setattr(main_module, "find_unprocessed_records", lambda _r: [])
+    monkeypatch.setattr(main_module, "read_json", lambda *_a, **_k: {})
+
+    assert main_module.main() == 0
+
+
+def test_main__process_records(monkeypatch):
+    args = SimpleNamespace(
+        media_csv="media.csv",
+        categories_csv="cats.csv",
+        log_dir="logs",
+        debug=False,
+        max_count=1,
+        interval=0,
+        batch_mode=False,
+        batch_size=1,
+        batch_wait_timeout=0,
+        batch_poll_interval=0,
+        check_batch_status=False,
+    )
+
+    monkeypatch.setattr(main_module, "parse_arguments", lambda: args)
+    monkeypatch.setattr(main_module, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(main_module, "setup_logging", lambda **_k: None)
+    monkeypatch.setattr(main_module, "get_config", lambda: object())
+    monkeypatch.setattr(main_module, "load_media_records", lambda _p: [{"Cesta": "C:/file.jpg"}])
+    monkeypatch.setattr(main_module, "load_categories", lambda _p: {})
+    monkeypatch.setattr(main_module, "find_unprocessed_records", lambda _r: [{"Cesta": "C:/file.jpg"}])
+    monkeypatch.setattr(main_module, "read_json", lambda *_a, **_k: {})
+    monkeypatch.setattr(main_module, "process_unmatched_files", lambda *_a, **_k: {"processed": 1, "failed": 0, "skipped": 0})
+
+    assert main_module.main() == 0

--- a/givephotobankreadymediafiles/tests/unit/test_lib_module_imports__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_lib_module_imports__scenarios.py
@@ -1,0 +1,94 @@
+"""
+Import smoke tests for givephotobankreadymediafileslib modules.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+
+def test_import_ai_coordinator():
+    import givephotobankreadymediafileslib.ai_coordinator  # noqa: F401
+
+
+def test_import_alternative_generator():
+    import givephotobankreadymediafileslib.alternative_generator  # noqa: F401
+
+
+def test_import_batch_description_dialog():
+    import givephotobankreadymediafileslib.batch_description_dialog  # noqa: F401
+
+
+def test_import_batch_lock():
+    import givephotobankreadymediafileslib.batch_lock  # noqa: F401
+
+
+def test_import_batch_manager():
+    import givephotobankreadymediafileslib.batch_manager  # noqa: F401
+
+
+def test_import_batch_prompts():
+    import givephotobankreadymediafileslib.batch_prompts  # noqa: F401
+
+
+def test_import_batch_state():
+    import givephotobankreadymediafileslib.batch_state  # noqa: F401
+
+
+def test_import_categories_manager():
+    import givephotobankreadymediafileslib.categories_manager  # noqa: F401
+
+
+def test_import_constants():
+    import givephotobankreadymediafileslib.constants  # noqa: F401
+
+
+def test_import_editorial_dialog():
+    import givephotobankreadymediafileslib.editorial_dialog  # noqa: F401
+
+
+def test_import_media_display():
+    import givephotobankreadymediafileslib.media_display  # noqa: F401
+
+
+def test_import_media_helper():
+    import givephotobankreadymediafileslib.media_helper  # noqa: F401
+
+
+def test_import_media_processor():
+    import givephotobankreadymediafileslib.media_processor  # noqa: F401
+
+
+def test_import_media_viewer_refactored():
+    import givephotobankreadymediafileslib.media_viewer_refactored  # noqa: F401
+
+
+def test_import_media_viewer():
+    import givephotobankreadymediafileslib.media_viewer  # noqa: F401
+
+
+def test_import_mediainfo_loader():
+    import givephotobankreadymediafileslib.mediainfo_loader  # noqa: F401
+
+
+def test_import_metadata_generator():
+    import givephotobankreadymediafileslib.metadata_generator  # noqa: F401
+
+
+def test_import_metadata_validator():
+    import givephotobankreadymediafileslib.metadata_validator  # noqa: F401
+
+
+def test_import_tag_entry():
+    import givephotobankreadymediafileslib.tag_entry  # noqa: F401
+
+
+def test_import_ui_components():
+    import givephotobankreadymediafileslib.ui_components  # noqa: F401
+
+
+def test_import_viewer_state():
+    import givephotobankreadymediafileslib.viewer_state  # noqa: F401

--- a/givephotobankreadymediafiles/tests/unit/test_main_module_imports__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_main_module_imports__scenarios.py
@@ -1,0 +1,22 @@
+"""
+Import smoke tests for top-level scripts.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+
+def test_import_givephotobankreadymediafiles():
+    import givephotobankreadymediafiles  # noqa: F401
+
+
+def test_import_generatealternatives():
+    import generatealternatives  # noqa: F401
+
+
+def test_import_preparemediafile():
+    import preparemediafile  # noqa: F401

--- a/givephotobankreadymediafiles/tests/unit/test_media_display__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_media_display__scenarios.py
@@ -1,0 +1,214 @@
+"""
+Unit tests for givephotobankreadymediafileslib/media_display.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+from givephotobankreadymediafileslib import media_display
+
+
+class DummyLabel:
+    def __init__(self):
+        self.configs = []
+        self.width = 800
+        self.height = 600
+
+    def configure(self, **kwargs):
+        self.configs.append(kwargs)
+
+    def update_idletasks(self):
+        return None
+
+    def winfo_width(self):
+        return self.width
+
+    def winfo_height(self):
+        return self.height
+
+
+class DummyButton:
+    def __init__(self):
+        self.texts = []
+
+    def configure(self, **kwargs):
+        if "text" in kwargs:
+            self.texts.append(kwargs["text"])
+
+
+class DummyScale:
+    def __init__(self):
+        self.values = []
+
+    def set(self, value):
+        self.values.append(value)
+
+
+class DummyRoot:
+    def __init__(self):
+        self.after_calls = []
+
+    def after(self, _ms, func):
+        self.after_calls.append(func)
+        return None
+
+
+class DummyLock:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+
+class DummyCapture:
+    def __init__(self, opened=True):
+        self._opened = opened
+        self.released = False
+        self.set_calls = []
+
+    def isOpened(self):
+        return self._opened
+
+    def get(self, _prop):
+        if _prop == media_display.cv2.CAP_PROP_FPS:
+            return 25
+        if _prop == media_display.cv2.CAP_PROP_FRAME_COUNT:
+            return 100
+        return 0
+
+    def read(self):
+        return False, None
+
+    def set(self, _prop, value):
+        self.set_calls.append(( _prop, value))
+
+    def release(self):
+        self.released = True
+
+
+def test_load_media__routes_to_video_or_image(monkeypatch):
+    display = media_display.MediaDisplay(DummyRoot())
+    called = []
+    monkeypatch.setattr(media_display, "is_video_file", lambda _p: True)
+    monkeypatch.setattr(display, "load_video", lambda _p: called.append("video"))
+    monkeypatch.setattr(display, "load_image", lambda _p: called.append("image"))
+
+    display.load_media("C:/file.mp4")
+    assert called == ["video"]
+
+    monkeypatch.setattr(media_display, "is_video_file", lambda _p: False)
+    display.load_media("C:/file.jpg")
+    assert called[-1] == "image"
+
+
+def test_load_image__error_sets_label(monkeypatch):
+    display = media_display.MediaDisplay(DummyRoot())
+    display.media_label = DummyLabel()
+
+    def raise_error(_p):
+        raise OSError("boom")
+
+    monkeypatch.setattr(media_display.Image, "open", raise_error)
+    display.load_image("C:/file.jpg")
+    assert any("Error loading image" in c.get("text", "") for c in display.media_label.configs)
+
+
+def test_resize_image__no_state_returns():
+    display = media_display.MediaDisplay(DummyRoot())
+    display.resize_image()
+
+
+def test_on_window_resize__schedules_resize(monkeypatch):
+    root = DummyRoot()
+    display = media_display.MediaDisplay(root)
+    display.current_file_path = "C:/file.jpg"
+    monkeypatch.setattr(media_display, "is_video_file", lambda _p: False)
+
+    event = SimpleNamespace(widget=root)
+    display.on_window_resize(event)
+    assert root.after_calls
+
+
+def test_load_video__open_failure(monkeypatch):
+    display = media_display.MediaDisplay(DummyRoot())
+    display.media_label = DummyLabel()
+    display.video_lock = DummyLock()
+
+    monkeypatch.setattr(media_display.cv2, "VideoCapture", lambda _p: DummyCapture(opened=False))
+    display.load_video("C:/file.mp4")
+    assert any("Error loading video" in c.get("text", "") for c in display.media_label.configs)
+
+
+def test_toggle_video__delegates(monkeypatch):
+    display = media_display.MediaDisplay(DummyRoot())
+    called = []
+    display.video_playing = True
+    display.pause_video = lambda: called.append("pause")
+    display.toggle_video()
+    assert called == ["pause"]
+
+    display.video_playing = False
+    display.play_video = lambda: called.append("play")
+    display.toggle_video()
+    assert called[-1] == "play"
+
+
+def test_pause_and_stop_video_updates_state():
+    display = media_display.MediaDisplay(DummyRoot())
+    display.play_button = DummyButton()
+    display.video_progress = DummyScale()
+    display.time_label = DummyLabel()
+    display.video_lock = DummyLock()
+    display.video_cap = DummyCapture(opened=True)
+
+    display.pause_video()
+    assert display.video_paused is True
+    assert display.play_button.texts[-1] == "Play"
+
+    display.stop_video()
+    assert display.video_cap is None
+    assert display.video_progress.values[-1] == 0
+
+
+def test_seek_video__spawns_thread(monkeypatch):
+    display = media_display.MediaDisplay(DummyRoot())
+    display.current_file_path = "C:/file.mp4"
+    display.video_cap = DummyCapture(opened=True)
+    display.video_frame_count = 100
+    display.video_lock = DummyLock()
+    monkeypatch.setattr(media_display, "is_video_file", lambda _p: True)
+
+    started = []
+
+    class DummyThread:
+        def __init__(self, target, args, daemon):
+            started.append((target, args, daemon))
+
+        def start(self):
+            return None
+
+    monkeypatch.setattr(media_display.threading, "Thread", DummyThread)
+    display.seek_video("50")
+    assert started
+
+
+def test_update_time_display__updates_progress():
+    display = media_display.MediaDisplay(DummyRoot())
+    display.time_label = DummyLabel()
+    display.video_progress = DummyScale()
+    display.video_cap = object()
+    display.video_fps = 25
+    display.video_frame_count = 100
+    display.video_duration = 4
+    display.current_frame_number = 50
+
+    display._update_time_display()
+    assert display.video_progress.values[-1] == 50.0

--- a/givephotobankreadymediafiles/tests/unit/test_media_helper__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_media_helper__scenarios.py
@@ -1,0 +1,117 @@
+"""
+Unit tests for givephotobankreadymediafileslib/media_helper.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from subprocess import CalledProcessError
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+from givephotobankreadymediafileslib import media_helper
+
+
+def test_open_media_file__missing_file(monkeypatch):
+    monkeypatch.setattr(media_helper.os.path, "exists", lambda _p: False)
+    assert media_helper.open_media_file("C:/missing.jpg") is False
+
+
+def test_open_media_file__windows(monkeypatch):
+    monkeypatch.setattr(media_helper.os.path, "exists", lambda _p: True)
+    monkeypatch.setattr(media_helper.os, "name", "nt")
+    called = []
+    monkeypatch.setattr(media_helper.os, "startfile", lambda path: called.append(path))
+
+    assert media_helper.open_media_file("C:/file.jpg") is True
+    assert called == ["C:/file.jpg"]
+
+
+def test_open_media_file__posix(monkeypatch):
+    monkeypatch.setattr(media_helper.os.path, "exists", lambda _p: True)
+    monkeypatch.setattr(media_helper.os, "name", "posix")
+    called = []
+
+    def fake_run(cmd, check):
+        called.append((cmd, check))
+
+    monkeypatch.setattr(media_helper.subprocess, "run", fake_run)
+
+    assert media_helper.open_media_file("/tmp/file.jpg") is True
+    assert called[0][0] == ["xdg-open", "/tmp/file.jpg"]
+
+
+def test_media_type_helpers():
+    assert media_helper.is_media_file("photo.jpg") is True
+    assert media_helper.is_video_file("clip.mp4") is True
+    assert media_helper.is_image_file("shot.png") is True
+    assert media_helper.is_jpg_file("shot.jpeg") is True
+    assert media_helper.get_media_type("clip.mp4") == "video"
+
+
+def test_get_file_info__missing(monkeypatch):
+    monkeypatch.setattr(media_helper.os.path, "exists", lambda _p: False)
+    assert media_helper.get_file_info("C:/missing.jpg") == {}
+
+
+def test_get_file_info__returns_fields(monkeypatch):
+    monkeypatch.setattr(media_helper.os.path, "exists", lambda _p: True)
+
+    class DummyStat:
+        st_size = 123
+        st_mtime = 456
+
+    monkeypatch.setattr(media_helper.os, "stat", lambda _p: DummyStat())
+
+    info = media_helper.get_file_info("C:/file.jpg")
+    assert info["size"] == 123
+    assert info["media_type"] == "image"
+
+
+def test_process_single_file__missing_file(monkeypatch):
+    monkeypatch.setattr(media_helper.os.path, "exists", lambda _p: False)
+    success, _path, error = media_helper.process_single_file("C:/missing.jpg")
+    assert success is False
+    assert "not found" in error.lower()
+
+
+def test_process_single_file__missing_script(monkeypatch):
+    def fake_exists(path):
+        return path.endswith(".jpg")
+
+    monkeypatch.setattr(media_helper.os.path, "exists", fake_exists)
+    success, _path, error = media_helper.process_single_file("C:/file.jpg")
+    assert success is False
+    assert "preparemediafile.py not found" in error
+
+
+def test_process_single_file__subprocess_error(monkeypatch):
+    def fake_exists(_p):
+        return True
+
+    monkeypatch.setattr(media_helper.os.path, "exists", fake_exists)
+
+    def fake_run(_cmd, check):
+        raise CalledProcessError(2, _cmd)
+
+    monkeypatch.setattr(media_helper.subprocess, "run", fake_run)
+    success, _path, error = media_helper.process_single_file("C:/file.jpg", media_csv="C:/media.csv")
+    assert success is False
+    assert "non-zero exit status" in error
+
+
+def test_process_unmatched_files__stats(monkeypatch):
+    records = [
+        {"Cesta": "C:/file.jpg", "Soubor": "file.jpg"},
+        {"Cesta": "", "Soubor": "missing.jpg"},
+    ]
+
+    monkeypatch.setattr(media_helper, "process_single_file", lambda *_args: (True, "C:/file.jpg", ""))
+    monkeypatch.setattr(media_helper.time, "sleep", lambda _s: None)
+
+    stats = media_helper.process_unmatched_files(records, max_count=2, interval=1)
+    assert stats["processed"] == 1
+    assert stats["skipped"] == 1

--- a/givephotobankreadymediafiles/tests/unit/test_media_processor__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_media_processor__scenarios.py
@@ -1,0 +1,60 @@
+"""
+Unit tests for givephotobankreadymediafileslib/media_processor.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+from givephotobankreadymediafileslib import media_processor
+
+
+def test_find_unprocessed_records__filters_and_sorts(monkeypatch):
+    monkeypatch.setattr(media_processor.os.path, "exists", lambda _p: True)
+
+    def fake_media_type(path):
+        return "video" if path.endswith(".mp4") else "image"
+
+    monkeypatch.setattr(media_processor, "get_media_type", fake_media_type)
+
+    records = [
+        {"Originál": "ano", "Soubor": "b.jpg", "Cesta": "C:/b.jpg", "Datum vytvoření": "02.01.2020",
+         "Test status": media_processor.STATUS_UNPROCESSED},
+        {"Originál": "ano", "Soubor": "a.mp4", "Cesta": "C:/a.mp4", "Datum vytvoření": "01.01.2020",
+         "Test status": media_processor.STATUS_UNPROCESSED},
+        {"Originál": "ne", "Soubor": "skip.jpg", "Cesta": "C:/skip.jpg", "Datum vytvoření": "01.01.2020",
+         "Test status": media_processor.STATUS_UNPROCESSED},
+    ]
+
+    result = media_processor.find_unprocessed_records(records)
+    assert [r["Soubor"] for r in result] == ["b.jpg", "a.mp4"]
+
+
+def test_find_unprocessed_records__missing_path_skips(monkeypatch):
+    monkeypatch.setattr(media_processor.os.path, "exists", lambda _p: False)
+
+    records = [
+        {"Originál": "ano", "Soubor": "a.jpg", "Cesta": "C:/a.jpg", "Test status": media_processor.STATUS_UNPROCESSED}
+    ]
+
+    assert media_processor.find_unprocessed_records(records) == []
+
+
+def test_find_unprocessed_records__invalid_date_falls_back(monkeypatch):
+    monkeypatch.setattr(media_processor.os.path, "exists", lambda _p: True)
+    monkeypatch.setattr(media_processor, "get_media_type", lambda _p: "image")
+
+    records = [
+        {"Originál": "ano", "Soubor": "b.jpg", "Cesta": "C:/b.jpg", "Datum vytvoření": "not-a-date",
+         "Test status": media_processor.STATUS_UNPROCESSED},
+        {"Originál": "ano", "Soubor": "a.jpg", "Cesta": "C:/a.jpg", "Datum vytvoření": "",
+         "Test status": media_processor.STATUS_UNPROCESSED},
+    ]
+
+    result = media_processor.find_unprocessed_records(records)
+    assert [r["Soubor"] for r in result] == ["a.jpg", "b.jpg"]

--- a/givephotobankreadymediafiles/tests/unit/test_media_viewer__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_media_viewer__scenarios.py
@@ -1,0 +1,193 @@
+"""
+Unit tests for givephotobankreadymediafileslib/media_viewer.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+from givephotobankreadymediafileslib import media_viewer
+
+
+class DummyEntry:
+    def __init__(self, value=""):
+        self.value = value
+
+    def get(self):
+        return self.value
+
+    def delete(self, *_args):
+        self.value = ""
+
+    def insert(self, _index, value):
+        self.value = value
+
+
+class DummyText:
+    def __init__(self, value=""):
+        self.value = value
+        self.foreground = None
+        self.focused = False
+
+    def get(self, *_args):
+        return self.value
+
+    def delete(self, *_args):
+        self.value = ""
+
+    def insert(self, _index, value):
+        self.value = value
+
+    def config(self, **kwargs):
+        self.foreground = kwargs.get("foreground", self.foreground)
+
+    def focus(self):
+        self.focused = True
+
+
+class DummyLabel:
+    def __init__(self):
+        self.text = None
+        self.foreground = None
+
+    def configure(self, **kwargs):
+        self.text = kwargs.get("text", self.text)
+        self.foreground = kwargs.get("foreground", self.foreground)
+
+
+class DummyButton:
+    def __init__(self):
+        self.state = "disabled"
+
+    def configure(self, state=None, **_kwargs):
+        if state is not None:
+            self.state = state
+
+    def __getitem__(self, key):
+        if key == "state":
+            return self.state
+        raise KeyError(key)
+
+
+class DummyModelCombo:
+    def __init__(self, value=""):
+        self.value = value
+
+    def get(self):
+        return self.value
+
+
+class DummyAIProvider:
+    def __init__(self, can_generate=True):
+        self.can_generate = can_generate
+
+    def can_generate_with_inputs(self, has_image, has_text):
+        return self.can_generate and (has_image or has_text)
+
+
+def _build_viewer():
+    viewer = media_viewer.MediaViewer.__new__(media_viewer.MediaViewer)
+    viewer.user_desc_placeholder = "placeholder"
+    viewer.user_desc_text = DummyText("placeholder")
+    viewer.title_entry = DummyEntry()
+    viewer.desc_text = DummyText()
+    viewer.title_char_label = DummyLabel()
+    viewer.desc_char_label = DummyLabel()
+    viewer.keywords_tag_entry = type("DummyTag", (), {"get_tags": lambda _s: ["one", "two"], "set_tags": lambda _s, _t: None})()
+    viewer.keywords_list = []
+    viewer.keywords_count_label = DummyLabel()
+    viewer._button_update_timer = None
+    viewer.root = type("DummyRoot", (), {"after_cancel": lambda *_a, **_k: None, "after": lambda *_a, **_k: "timer"})()
+    viewer.ai_threads = {"title": None}
+    viewer.title_generate_button = DummyButton()
+    viewer.desc_generate_button = DummyButton()
+    viewer.keywords_generate_button = DummyButton()
+    viewer.categories_generate_button = DummyButton()
+    viewer.generate_all_button = DummyButton()
+    viewer.model_combo = DummyModelCombo()
+    return viewer
+
+
+def test_user_desc_placeholder_focus_in_out():
+    viewer = _build_viewer()
+    viewer.on_user_desc_focus_in()
+    assert viewer.user_desc_text.value == ""
+    assert viewer.user_desc_text.foreground == "black"
+
+    viewer.on_user_desc_focus_out()
+    assert viewer.user_desc_text.value == "placeholder"
+    assert viewer.user_desc_text.foreground == "gray"
+
+
+def test_get_user_description():
+    viewer = _build_viewer()
+    assert viewer.get_user_description() is None
+    viewer.user_desc_text.value = "Real text"
+    assert viewer.get_user_description() == "Real text"
+
+
+def test_title_and_description_change_truncates():
+    viewer = _build_viewer()
+    viewer.title_entry.value = "x" * (media_viewer.MAX_TITLE_LENGTH + 1)
+    viewer.on_title_change()
+    assert len(viewer.title_entry.get()) == media_viewer.MAX_TITLE_LENGTH
+
+    viewer.desc_text.value = "x" * (media_viewer.MAX_DESCRIPTION_LENGTH + 1)
+    viewer.on_description_change()
+    assert len(viewer.desc_text.get()) == media_viewer.MAX_DESCRIPTION_LENGTH
+
+
+def test_keywords_change_updates_counter():
+    viewer = _build_viewer()
+    viewer.on_keywords_change()
+    assert viewer.keywords_list == ["one", "two"]
+    assert viewer.keywords_count_label.text == "2/50"
+
+
+def test_update_all_button_states_debounced():
+    viewer = _build_viewer()
+    calls = []
+    viewer.root.after = lambda *_a, **_k: calls.append(True) or "timer"
+
+    viewer.update_all_button_states_debounced()
+    assert calls
+
+
+def test_check_available_inputs(monkeypatch):
+    viewer = _build_viewer()
+    viewer.current_file_path = "C:/file.jpg"
+    monkeypatch.setattr(media_viewer.os.path, "exists", lambda _p: True)
+    viewer.title_entry.value = "title"
+    inputs = viewer.check_available_inputs("title")
+    assert inputs["has_image"] is True
+    assert inputs["has_text"] is True
+
+
+def test_should_enable_generation_button__no_file():
+    viewer = _build_viewer()
+    viewer.current_file_path = None
+    assert viewer.should_enable_generation_button("title") is False
+
+
+def test_should_enable_generation_button__provider():
+    viewer = _build_viewer()
+    viewer.current_file_path = "C:/file.jpg"
+    provider = DummyAIProvider(can_generate=True)
+    assert viewer.should_enable_generation_button("title", provider) is True
+
+
+def test_update_button_state__thread_alive(monkeypatch):
+    viewer = _build_viewer()
+
+    class DummyThread:
+        def is_alive(self):
+            return True
+
+    viewer.ai_threads["title"] = DummyThread()
+    viewer.update_button_state("title", viewer.title_generate_button, DummyAIProvider())
+    assert viewer.title_generate_button.state == "disabled"

--- a/givephotobankreadymediafiles/tests/unit/test_media_viewer_refactored__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_media_viewer_refactored__scenarios.py
@@ -1,0 +1,208 @@
+"""
+Unit tests for givephotobankreadymediafileslib/media_viewer_refactored.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+from givephotobankreadymediafileslib import media_viewer_refactored
+
+
+class DummyRoot:
+    def __init__(self):
+        self.destroyed = False
+
+    def destroy(self):
+        self.destroyed = True
+
+
+class DummyLabel:
+    def __init__(self):
+        self.text = None
+
+    def configure(self, **kwargs):
+        self.text = kwargs.get("text")
+
+
+class DummyEntry:
+    def __init__(self):
+        self.focused = False
+
+    def focus(self):
+        self.focused = True
+
+
+def _build_viewer():
+    viewer = media_viewer_refactored.MediaViewerRefactored.__new__(media_viewer_refactored.MediaViewerRefactored)
+    viewer.root = DummyRoot()
+    viewer.viewer_state = SimpleNamespace(
+        current_file_path=None,
+        current_record=None,
+        completion_callback=None,
+        collect_metadata=lambda: {"title": "t", "description": "d", "keywords": "k", "editorial": False},
+        load_metadata_from_record=lambda _r: None,
+        title_entry=DummyEntry(),
+    )
+    viewer.media_display = SimpleNamespace(clear_media=lambda: None, load_media=lambda _p: None)
+    viewer.categories_manager = SimpleNamespace(
+        load_existing_categories=lambda _r: None,
+        collect_selected_categories=lambda: {"ShutterStock": ["A"]},
+    )
+    viewer.ui_components = SimpleNamespace(file_path_label=DummyLabel(), model_combo=SimpleNamespace(get=lambda: "Model A"))
+    viewer.metadata_validator = SimpleNamespace(update_all_button_states=lambda: None)
+    return viewer
+
+
+def test_on_model_selected__updates_buttons():
+    viewer = _build_viewer()
+    called = []
+    viewer.metadata_validator.update_all_button_states = lambda: called.append(True)
+
+    viewer.on_model_selected()
+    assert called
+
+
+def test_load_media__wires_state():
+    viewer = _build_viewer()
+    called = []
+    viewer.media_display.clear_media = lambda: called.append("clear")
+    viewer.media_display.load_media = lambda _p: called.append("load")
+    viewer.viewer_state.load_metadata_from_record = lambda _r: called.append("metadata")
+    viewer.categories_manager.load_existing_categories = lambda _r: called.append("categories")
+    viewer.metadata_validator.update_all_button_states = lambda: called.append("buttons")
+
+    viewer.load_media("C:/file.jpg", {"a": 1}, completion_callback=lambda _m: True)
+    assert viewer.viewer_state.current_file_path == "C:/file.jpg"
+    assert viewer.ui_components.file_path_label.text == "C:/file.jpg"
+    assert "load" in called
+    assert viewer.viewer_state.title_entry.focused is True
+
+
+def test_save_metadata__no_record(monkeypatch):
+    viewer = _build_viewer()
+    viewer.viewer_state.current_record = None
+    called = []
+    monkeypatch.setattr(media_viewer_refactored.messagebox, "showwarning", lambda *_a, **_k: called.append(True))
+
+    viewer.save_metadata()
+    assert called
+
+
+def test_save_metadata__success():
+    viewer = _build_viewer()
+    viewer.viewer_state.current_record = {"a": 1}
+    viewer.viewer_state.completion_callback = lambda _m: True
+
+    viewer.save_metadata()
+    assert viewer.root.destroyed is True
+
+
+def test_save_metadata__failure(monkeypatch):
+    viewer = _build_viewer()
+    viewer.viewer_state.current_record = {"a": 1}
+    viewer.viewer_state.completion_callback = lambda _m: False
+    called = []
+    monkeypatch.setattr(media_viewer_refactored.messagebox, "showerror", lambda *_a, **_k: called.append(True))
+
+    viewer.save_metadata()
+    assert called
+    assert viewer.root.destroyed is False
+
+
+def test_reject_metadata__no_record(monkeypatch):
+    viewer = _build_viewer()
+    viewer.viewer_state.current_record = None
+    called = []
+    monkeypatch.setattr(media_viewer_refactored.messagebox, "showwarning", lambda *_a, **_k: called.append(True))
+
+    viewer.reject_metadata()
+    assert called
+
+
+def test_reject_metadata__confirmed(monkeypatch):
+    viewer = _build_viewer()
+    viewer.viewer_state.current_record = {"a": 1}
+    viewer.viewer_state.current_file_path = "C:/file.jpg"
+    called = []
+    viewer.viewer_state.completion_callback = lambda _m: called.append(_m)
+    monkeypatch.setattr(media_viewer_refactored.messagebox, "askyesno", lambda *_a, **_k: True)
+
+    viewer.reject_metadata()
+    assert called
+    assert viewer.root.destroyed is True
+
+
+def test_open_in_explorer__no_file(monkeypatch):
+    viewer = _build_viewer()
+    viewer.viewer_state.current_file_path = None
+    called = []
+    monkeypatch.setattr(media_viewer_refactored.messagebox, "showwarning", lambda *_a, **_k: called.append(True))
+
+    viewer.open_in_explorer()
+    assert called
+
+
+def test_open_in_explorer__windows(monkeypatch):
+    viewer = _build_viewer()
+    viewer.viewer_state.current_file_path = "C:/file.jpg"
+    monkeypatch.setattr(media_viewer_refactored.platform, "system", lambda: "Windows")
+    called = []
+    monkeypatch.setattr(media_viewer_refactored.subprocess, "run", lambda *_a, **_k: SimpleNamespace(returncode=0))
+    viewer.open_in_explorer()
+    assert viewer.root.destroyed is False
+
+
+def test_on_window_close__exits(monkeypatch):
+    viewer = _build_viewer()
+    called = []
+    monkeypatch.setattr(media_viewer_refactored.sys, "exit", lambda code: called.append(code))
+
+    viewer.on_window_close()
+    assert viewer.root.destroyed is True
+    assert called == [0]
+
+
+def test_show_media_viewer__creates_and_loads(monkeypatch):
+    called = []
+
+    class DummyRoot:
+        def update_idletasks(self):
+            return None
+
+        def winfo_screenwidth(self):
+            return 1000
+
+        def winfo_screenheight(self):
+            return 800
+
+        def winfo_width(self):
+            return 500
+
+        def winfo_height(self):
+            return 400
+
+        def geometry(self, _value):
+            called.append("geometry")
+
+        def mainloop(self):
+            called.append("mainloop")
+
+    class DummyViewer:
+        def __init__(self, root, _target, _categories):
+            self.root = root
+
+        def load_media(self, file_path, record, completion_callback):
+            called.append((file_path, record, completion_callback))
+
+    monkeypatch.setattr(media_viewer_refactored.tk, "Tk", lambda: DummyRoot())
+    monkeypatch.setattr(media_viewer_refactored, "MediaViewerRefactored", DummyViewer)
+
+    media_viewer_refactored.show_media_viewer("C:/file.jpg", {"a": 1}, None, {})
+    assert ("C:/file.jpg", {"a": 1}, None) in called

--- a/givephotobankreadymediafiles/tests/unit/test_mediainfo_loader__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_mediainfo_loader__scenarios.py
@@ -1,0 +1,52 @@
+"""
+Unit tests for givephotobankreadymediafileslib/mediainfo_loader.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+from givephotobankreadymediafileslib import mediainfo_loader
+
+
+def test_load_media_records__missing_file(monkeypatch):
+    monkeypatch.setattr(mediainfo_loader.os.path, "exists", lambda _p: False)
+    assert mediainfo_loader.load_media_records("missing.csv") == []
+
+
+def test_load_media_records__loads_csv(monkeypatch):
+    monkeypatch.setattr(mediainfo_loader.os.path, "exists", lambda _p: True)
+    monkeypatch.setattr(mediainfo_loader, "load_csv", lambda _p: [{"Soubor": "a.jpg"}])
+
+    result = mediainfo_loader.load_media_records("media.csv")
+    assert result == [{"Soubor": "a.jpg"}]
+
+
+def test_load_categories__missing_file(monkeypatch):
+    monkeypatch.setattr(mediainfo_loader.os.path, "exists", lambda _p: False)
+    assert mediainfo_loader.load_categories("cats.csv") == {}
+
+
+def test_load_categories__empty_records(monkeypatch):
+    monkeypatch.setattr(mediainfo_loader.os.path, "exists", lambda _p: True)
+    monkeypatch.setattr(mediainfo_loader, "load_csv", lambda _p: [])
+
+    assert mediainfo_loader.load_categories("cats.csv") == {}
+
+
+def test_load_categories__builds_mapping(monkeypatch):
+    records = [
+        {"ShutterStock": "Animals", "AdobeStock": "Nature"},
+        {"ShutterStock": "People", "AdobeStock": ""},
+    ]
+    monkeypatch.setattr(mediainfo_loader.os.path, "exists", lambda _p: True)
+    monkeypatch.setattr(mediainfo_loader, "load_csv", lambda _p: records)
+
+    categories = mediainfo_loader.load_categories("cats.csv")
+    assert categories["ShutterStock"] == ["Animals", "People"]
+    assert categories["AdobeStock"] == ["Nature"]

--- a/givephotobankreadymediafiles/tests/unit/test_metadata_generator__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_metadata_generator__scenarios.py
@@ -1,0 +1,144 @@
+"""
+Unit tests for givephotobankreadymediafileslib/metadata_generator.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+from givephotobankreadymediafileslib import metadata_generator
+
+
+class DummyProvider:
+    def __init__(self, supports_images=True):
+        self._supports_images = supports_images
+
+    def supports_images(self):
+        return self._supports_images
+
+
+class DummyPromptManager:
+    def get_character_limits(self):
+        return {"title": 80, "description": 200, "keywords_max": 50}
+
+    def get_photobank_limits(self):
+        return {"shutterstock": 2}
+
+
+def _make_generator():
+    provider = DummyProvider()
+    gen = metadata_generator.MetadataGenerator.__new__(metadata_generator.MetadataGenerator)
+    gen.ai_provider = provider
+    gen.prompt_manager = DummyPromptManager()
+    gen.max_title_length = 80
+    gen.max_description_length = 200
+    gen.max_keywords = 50
+    gen.photobank_categories = {}
+    return gen
+
+
+def test_clean_title_and_description():
+    gen = _make_generator()
+    assert gen._clean_title("Title: hello") == "Hello"
+    assert gen._clean_description("Description: text") == "text"
+
+
+def test_truncate_to_sentence__punctuation():
+    gen = _make_generator()
+    text = "Sentence one. Sentence two is long."
+    result = gen._truncate_to_sentence(text, max_length=20)
+    assert result.endswith(".")
+
+
+def test_truncate_to_sentence__word_boundary():
+    gen = _make_generator()
+    result = gen._truncate_to_sentence("No punctuation here", max_length=10)
+    assert result == "No"
+
+
+def test_validate_keyword__removes_diacritics_and_symbols():
+    gen = _make_generator()
+    assert gen._validate_keyword("bláh-!?") == "blah"
+
+
+def test_parse_keywords__dedupe():
+    gen = _make_generator()
+    result = gen._parse_keywords("Tree, tree, lake")
+    assert result == ["Tree", "lake"]
+
+
+def test_remove_duplicate_keywords__removes_multi_word():
+    gen = _make_generator()
+    result = gen._remove_duplicate_keywords(["blue", "pond", "blue pond"])
+    assert result == ["blue", "pond"]
+
+
+def test_parse_categories__limits():
+    gen = _make_generator()
+    available = ["Nature", "People", "Travel"]
+    result = gen._parse_categories("Nature, Travel", available, "ShutterStock")
+    assert result == ["Nature", "Travel"]
+
+
+def test_find_best_category_match():
+    gen = _make_generator()
+    available = ["Nature", "People"]
+    assert gen._find_best_category_match("nature", available) == "Nature"
+    assert gen._find_best_category_match("peo", available) == "People"
+    assert gen._find_best_category_match("other", available) is None
+
+
+def test_parse_editorial_response():
+    gen = _make_generator()
+    assert gen._parse_editorial_response("YES - editorial") is True
+    assert gen._parse_editorial_response("no") is False
+
+
+def test_fallback_categories():
+    gen = _make_generator()
+    available = ["Other", "Nature"]
+    assert gen._fallback_categories("ShutterStock", available) == ["Other"]
+
+
+def test_generate_categories__unsupported_provider():
+    provider = DummyProvider(supports_images=False)
+    gen = metadata_generator.MetadataGenerator.__new__(metadata_generator.MetadataGenerator)
+    gen.ai_provider = provider
+    gen.prompt_manager = DummyPromptManager()
+    gen.max_title_length = 80
+    gen.max_description_length = 200
+    gen.max_keywords = 50
+    gen.photobank_categories = {}
+    gen.set_photobank_categories({"ShutterStock": ["Other", "Nature"]})
+    categories = gen.generate_categories("C:/file.jpg")
+    assert categories["ShutterStock"] == ["Other"]
+
+
+def test_generate_title__unsupported_provider():
+    provider = DummyProvider(supports_images=False)
+    gen = metadata_generator.MetadataGenerator.__new__(metadata_generator.MetadataGenerator)
+    gen.ai_provider = provider
+    gen.prompt_manager = DummyPromptManager()
+    gen.max_title_length = 80
+    gen.max_description_length = 200
+    gen.max_keywords = 50
+    gen.photobank_categories = {}
+    try:
+        gen.generate_title("C:/file.jpg")
+    except ValueError as exc:
+        assert "does not support image" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError")
+
+
+def test_create_metadata_generator__uses_factory(monkeypatch):
+    called = []
+    monkeypatch.setattr(metadata_generator, "create_from_model_key", lambda key, **_k: called.append(key) or DummyProvider())
+    gen = metadata_generator.create_metadata_generator("provider/model")
+    assert isinstance(gen, metadata_generator.MetadataGenerator)
+    assert called == ["provider/model"]

--- a/givephotobankreadymediafiles/tests/unit/test_metadata_validator__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_metadata_validator__scenarios.py
@@ -1,0 +1,170 @@
+"""
+Unit tests for givephotobankreadymediafileslib/metadata_validator.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+from givephotobankreadymediafileslib import metadata_validator
+
+
+class DummyEntry:
+    def __init__(self, value=""):
+        self._value = value
+
+    def get(self):
+        return self._value
+
+
+class DummyText:
+    def __init__(self, value=""):
+        self._value = value
+
+    def get(self, *_args):
+        return self._value
+
+
+class DummyButton:
+    def __init__(self):
+        self.state = "disabled"
+
+    def configure(self, state=None, **_kwargs):
+        if state is not None:
+            self.state = state
+
+    def __getitem__(self, key):
+        if key == "state":
+            return self.state
+        raise KeyError(key)
+
+
+class DummyLock:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+
+class DummyModelCombo:
+    def __init__(self, value=""):
+        self._value = value
+
+    def get(self):
+        return self._value
+
+
+class DummyAIProvider:
+    def __init__(self, can_generate=True):
+        self._can_generate = can_generate
+
+    def can_generate_with_inputs(self, has_image, has_text):
+        return self._can_generate and (has_image or has_text)
+
+
+class DummyViewerState:
+    def __init__(self, file_path=None, title="", desc="", keywords=None):
+        self.current_file_path = file_path
+        self.title_entry = DummyEntry(title)
+        self.desc_text = DummyText(desc)
+        self.keywords_list = keywords or []
+
+
+class DummyAI:
+    def __init__(self, provider=None):
+        self._provider = provider
+        self.generation_lock = DummyLock()
+        self.ai_threads = {}
+
+    def get_current_ai_provider(self):
+        return self._provider
+
+
+class DummyUI:
+    def __init__(self):
+        self.model_combo = DummyModelCombo()
+        self.title_generate_button = DummyButton()
+        self.desc_generate_button = DummyButton()
+        self.keywords_generate_button = DummyButton()
+        self.categories_generate_button = DummyButton()
+        self.generate_all_button = DummyButton()
+
+
+def test_check_available_inputs__fields(monkeypatch):
+    monkeypatch.setattr(metadata_validator.os.path, "exists", lambda _p: True)
+    viewer_state = DummyViewerState(file_path="C:/file.jpg", title="t", desc="d", keywords=["k"])
+    validator = metadata_validator.MetadataValidator(viewer_state, DummyUI(), DummyAI(), object())
+
+    assert validator.check_available_inputs("title") == {"has_image": True, "has_text": True}
+    assert validator.check_available_inputs("description") == {"has_image": True, "has_text": True}
+    assert validator.check_available_inputs("keywords") == {"has_image": True, "has_text": True}
+    assert validator.check_available_inputs("categories") == {"has_image": True, "has_text": True}
+
+
+def test_should_enable_generation_button__no_file():
+    viewer_state = DummyViewerState(file_path=None)
+    validator = metadata_validator.MetadataValidator(viewer_state, DummyUI(), DummyAI(), object())
+
+    assert validator.should_enable_generation_button("title") is False
+
+
+def test_should_enable_generation_button__provider_can_generate(monkeypatch):
+    monkeypatch.setattr(metadata_validator.os.path, "exists", lambda _p: True)
+    viewer_state = DummyViewerState(file_path="C:/file.jpg", title="title")
+    provider = DummyAIProvider(can_generate=True)
+    validator = metadata_validator.MetadataValidator(viewer_state, DummyUI(), DummyAI(provider), object())
+
+    assert validator.should_enable_generation_button("title", ai_provider=provider) is True
+
+
+def test_should_enable_generation_button__provider_missing(monkeypatch):
+    monkeypatch.setattr(metadata_validator.os.path, "exists", lambda _p: True)
+
+    class DummyConfig:
+        def get_default_ai_model(self):
+            return ("provider", "model")
+
+    import shared.config as shared_config
+
+    monkeypatch.setattr(shared_config, "get_config", lambda: DummyConfig())
+    viewer_state = DummyViewerState(file_path="C:/file.jpg")
+    ui = DummyUI()
+    validator = metadata_validator.MetadataValidator(viewer_state, ui, DummyAI(provider=None), object())
+
+    assert validator.should_enable_generation_button("title") is False
+
+
+def test_update_all_button_states__enables_when_any(monkeypatch):
+    monkeypatch.setattr(metadata_validator.os.path, "exists", lambda _p: True)
+    viewer_state = DummyViewerState(file_path="C:/file.jpg", title="title")
+    provider = DummyAIProvider(can_generate=True)
+    ui = DummyUI()
+    validator = metadata_validator.MetadataValidator(viewer_state, ui, DummyAI(provider), object())
+
+    validator.update_all_button_states()
+    assert ui.generate_all_button.state == "normal"
+
+
+def test_update_button_state__skips_when_thread_alive(monkeypatch):
+    monkeypatch.setattr(metadata_validator.os.path, "exists", lambda _p: True)
+    viewer_state = DummyViewerState(file_path="C:/file.jpg", title="title")
+    provider = DummyAIProvider(can_generate=True)
+    ui = DummyUI()
+    ai = DummyAI(provider)
+
+    class DummyThread:
+        def is_alive(self):
+            return True
+
+    ai.ai_threads["title"] = DummyThread()
+    validator = metadata_validator.MetadataValidator(viewer_state, ui, ai, object())
+
+    ui.title_generate_button.state = "disabled"
+    validator.update_button_state("title", ui.title_generate_button, provider)
+    assert ui.title_generate_button.state == "disabled"

--- a/givephotobankreadymediafiles/tests/unit/test_preparemediafile__main__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_preparemediafile__main__scenarios.py
@@ -1,0 +1,56 @@
+"""
+Unit tests for givephotobankreadymediafiles/preparemediafile.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+import preparemediafile as script
+
+
+def test_main__missing_file(monkeypatch):
+    args = SimpleNamespace(
+        file="C:/missing.jpg",
+        media_csv="media.csv",
+        categories_csv="cats.csv",
+        log_dir="logs",
+        debug=False,
+    )
+
+    monkeypatch.setattr(script, "parse_arguments", lambda: args)
+    monkeypatch.setattr(script, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(script, "setup_logging", lambda **_k: None)
+    monkeypatch.setattr(script.os.path, "exists", lambda _p: False)
+
+    assert script.main() == 1
+
+
+def test_main__no_metadata_saved(monkeypatch):
+    args = SimpleNamespace(
+        file="C:/file.jpg",
+        media_csv="media.csv",
+        categories_csv="cats.csv",
+        log_dir="logs",
+        debug=False,
+    )
+
+    monkeypatch.setattr(script, "parse_arguments", lambda: args)
+    monkeypatch.setattr(script, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(script, "setup_logging", lambda **_k: None)
+
+    def fake_exists(path):
+        return path == args.file
+
+    monkeypatch.setattr(script.os.path, "exists", fake_exists)
+    monkeypatch.setattr(script, "load_categories", lambda _p: {})
+    monkeypatch.setattr(script, "load_media_records", lambda _p: [])
+    monkeypatch.setattr(script, "show_media_viewer", lambda *_a, **_k: None)
+
+    assert script.main() == 0

--- a/givephotobankreadymediafiles/tests/unit/test_shared_ai_factory__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_shared_ai_factory__scenarios.py
@@ -1,0 +1,28 @@
+"""
+Unit tests for givephotobankreadymediafiles/shared/ai_factory.py.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+import shared.ai_factory as ai_factory
+
+
+def test_get_available_models__returns_list():
+    factory = ai_factory.AIFactory()
+    models = factory.get_available_models(ai_factory.ProviderType.OPENAI)
+
+    assert isinstance(models, list)
+    assert "gpt-4o" in models
+
+
+def test_create_from_model_selector__invalid_format():
+    factory = ai_factory.AIFactory()
+    with pytest.raises(ValueError):
+        factory.create_from_model_selector("invalid_key")

--- a/givephotobankreadymediafiles/tests/unit/test_shared_ai_module__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_shared_ai_module__scenarios.py
@@ -1,0 +1,21 @@
+"""
+Unit tests for givephotobankreadymediafiles/shared/ai_module.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+import shared.ai_module as ai_module
+
+
+def test_ai_module_exports():
+    for name in ai_module.__all__:
+        assert hasattr(ai_module, name)
+
+
+def test_ai_module_version():
+    assert ai_module.__version__ == "1.0.0"

--- a/givephotobankreadymediafiles/tests/unit/test_shared_ai_provider__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_shared_ai_provider__scenarios.py
@@ -1,0 +1,46 @@
+"""
+Unit tests for givephotobankreadymediafiles/shared/ai_provider.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+from shared.ai_provider import ContentBlock, Message, MessageRole, AIProvider, AIResponse
+
+
+class DummyProvider(AIProvider):
+    def generate_text(self, messages, **kwargs):
+        return AIResponse(content="ok", model=self.model_name)
+
+    def generate_text_stream(self, messages, **kwargs):
+        yield "ok"
+
+    def create_batch_job(self, messages_list, custom_ids, **kwargs):
+        raise NotImplementedError
+
+    def get_batch_job(self, job_id):
+        raise NotImplementedError
+
+    def cancel_batch_job(self, job_id):
+        return False
+
+
+def test_content_block_text():
+    block = ContentBlock.text("hello")
+    assert block.type.name == "TEXT"
+    assert block.content == "hello"
+
+
+def test_message_factories():
+    msg = Message.system("sys")
+    assert msg.role == MessageRole.SYSTEM
+    assert Message.user_text("hi").content == "hi"
+
+
+def test_ai_provider_chat():
+    provider = DummyProvider("dummy")
+    assert provider.chat("hello") == "ok"

--- a/givephotobankreadymediafiles/tests/unit/test_shared_anthropic_provider__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_shared_anthropic_provider__scenarios.py
@@ -1,0 +1,212 @@
+"""
+Unit tests for givephotobankreadymediafiles/shared/anthropic_provider.py.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+from shared.ai_provider import ContentBlock, Message, MessageRole
+from shared.anthropic_provider import AnthropicProvider
+
+
+class DummyBlock:
+    def __init__(self, text):
+        self.text = text
+
+
+class DummyUsage:
+    def __init__(self, input_tokens, output_tokens):
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
+
+
+class DummyResponse:
+    def __init__(self):
+        self.id = "resp"
+        self.model = "claude-3-5-sonnet-20241022"
+        self.type = "message"
+        self.role = "assistant"
+        self.stop_reason = "stop"
+        self.usage = DummyUsage(3, 4)
+        self.content = [DummyBlock("hello")]
+
+
+class DummyEvent:
+    def __init__(self, text):
+        self.type = "content_block_delta"
+        self.delta = type("delta", (), {"text": text})
+
+
+class DummyStream:
+    def __init__(self, events):
+        self.events = events
+
+    def __enter__(self):
+        return self.events
+
+    def __exit__(self, _exc_type, _exc, _tb):
+        return False
+
+
+class DummyMessages:
+    def __init__(self):
+        self.created = None
+        self.stream_events = None
+
+    def create(self, **kwargs):
+        self.created = kwargs
+        return DummyResponse()
+
+    def stream(self, **kwargs):
+        self.created = kwargs
+        return DummyStream(self.stream_events)
+
+    class batches:
+        created = None
+        retrieve_value = None
+        results_value = None
+        cancelled = []
+
+        @classmethod
+        def create(cls, **kwargs):
+            cls.created = kwargs
+            return type(
+                "obj",
+                (),
+                {
+                    "id": "batch1",
+                    "processing_status": "in_progress",
+                    "created_at": "now",
+                    "type": "batch",
+                    "request_counts": type("rc", (), {"__dict__": {"total": 1}})(),
+                },
+            )
+
+        @classmethod
+        def retrieve(cls, job_id):
+            return cls.retrieve_value
+
+        @classmethod
+        def results(cls, job_id):
+            return cls.results_value
+
+        @classmethod
+        def cancel(cls, job_id):
+            cls.cancelled.append(job_id)
+
+
+class DummyClient:
+    def __init__(self):
+        self.messages = DummyMessages()
+
+
+def test_convert_messages_handles_system_and_images():
+    provider = AnthropicProvider()
+    messages = [
+        Message.system("sys"),
+        Message.user_text("hi"),
+        Message(
+            role=MessageRole.USER,
+            content=[
+                ContentBlock.text("t"),
+                ContentBlock.image_base64("AAA", metadata={"mime_type": "image/png"}),
+                ContentBlock.image_url("http://img"),
+            ],
+        ),
+    ]
+    converted = provider._convert_messages(messages)
+    assert converted["system"] == "sys"
+    assert converted["messages"][0]["content"] == "hi"
+    assert converted["messages"][1]["content"][0]["type"] == "text"
+    assert converted["messages"][1]["content"][1]["type"] == "image"
+
+
+def test_make_request_and_stream():
+    provider = AnthropicProvider()
+    provider._client = DummyClient()
+    provider._client.messages.stream_events = [DummyEvent("a"), DummyEvent("b")]
+
+    response = provider._make_request([Message.user_text("hi")])
+    assert response.content == "hello"
+
+    chunks = list(provider._make_stream_request([Message.user_text("hi")]))
+    assert chunks == ["a", "b"]
+
+
+def test_create_and_get_batch_job():
+    provider = AnthropicProvider()
+    provider._client = DummyClient()
+
+    job = provider.create_batch_job([[Message.user_text("hi")]], ["id1"])
+    assert job.job_id == "batch1"
+
+    provider._client.messages.batches.retrieve_value = type(
+        "obj",
+        (),
+        {
+            "processing_status": "ended",
+            "created_at": "now",
+            "ended_at": "done",
+            "type": "batch",
+            "expires_at": "later",
+            "request_counts": None,
+        },
+    )
+
+    result_message = type(
+        "msg",
+        (),
+        {
+            "content": [DummyBlock("ok")],
+            "model": "claude-3-5-sonnet-20241022",
+            "usage": DummyUsage(1, 2),
+            "stop_reason": "stop",
+        },
+    )
+    result_item = type(
+        "obj",
+        (),
+        {
+            "custom_id": "id1",
+            "result": type("res", (), {"type": "succeeded", "message": result_message})(),
+        },
+    )
+    provider._client.messages.batches.results_value = [result_item]
+
+    job = provider.get_batch_job("batch1")
+    assert job.status == "ended"
+    assert job.results[0].content == "ok"
+
+
+def test_cancel_batch_job():
+    provider = AnthropicProvider()
+    provider._client = DummyClient()
+    assert provider.cancel_batch_job("job") is True
+
+
+def test_cancel_batch_job_failure():
+    provider = AnthropicProvider()
+    provider._client = DummyClient()
+
+    def raise_error(_job_id):
+        raise RuntimeError("fail")
+
+    provider._client.messages.batches.cancel = raise_error
+    assert provider.cancel_batch_job("job") is False
+
+
+def test_supports_images_and_context_limit():
+    provider = AnthropicProvider(model_name="claude-3-5-sonnet-20241022")
+    assert provider.supports_images() is True
+    assert provider.get_context_limit() == 200_000
+
+
+def test_calculate_cost_unknown_model():
+    provider = AnthropicProvider(model_name="unknown")
+    assert provider._calculate_cost({"input_tokens": 10, "output_tokens": 20}) == 0.0

--- a/givephotobankreadymediafiles/tests/unit/test_shared_cloud_ai__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_shared_cloud_ai__scenarios.py
@@ -1,0 +1,114 @@
+"""
+Unit tests for givephotobankreadymediafiles/shared/cloud_ai.py.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+from shared.ai_provider import AIResponse, Message
+from shared.cloud_ai import CloudAIProvider
+
+
+class DummyCloud(CloudAIProvider):
+    def __init__(self, model_name, **kwargs):
+        super().__init__(model_name, **kwargs)
+        self.stream_chunks = []
+        self.make_request_calls = 0
+
+    def _make_request(self, messages, **kwargs):
+        self.make_request_calls += 1
+        return AIResponse(
+            content="ok",
+            model=self.model_name,
+            usage={"total_tokens": 5},
+            finish_reason="stop",
+        )
+
+    def _make_stream_request(self, messages, **kwargs):
+        for chunk in self.stream_chunks:
+            yield chunk
+
+    def _calculate_cost(self, usage):
+        return 0.1
+
+
+def test_wait_for_rate_limit(monkeypatch):
+    provider = DummyCloud("dummy", requests_per_minute=60)
+    provider.last_request_time = 0
+
+    times = iter([0.1, 0.1, 1.1])
+    slept = {}
+
+    def fake_time():
+        return next(times)
+
+    def fake_sleep(seconds):
+        slept["value"] = seconds
+
+    monkeypatch.setattr("shared.cloud_ai.time.time", fake_time)
+    monkeypatch.setattr("shared.cloud_ai.time.sleep", fake_sleep)
+
+    provider._wait_for_rate_limit()
+    assert slept["value"] > 0
+    assert provider.last_request_time == 1.1
+
+
+def test_retry_on_failure(monkeypatch):
+    provider = DummyCloud("dummy", max_retries=2, retry_delay=0)
+    calls = {"count": 0}
+
+    def flaky():
+        calls["count"] += 1
+        if calls["count"] < 3:
+            raise ValueError("no")
+        return "ok"
+
+    monkeypatch.setattr("shared.cloud_ai.time.sleep", lambda _s: None)
+    assert provider._retry_on_failure(flaky) == "ok"
+    assert calls["count"] == 3
+
+
+def test_retry_exhausted(monkeypatch):
+    provider = DummyCloud("dummy", max_retries=1, retry_delay=0)
+
+    def always_fail():
+        raise RuntimeError("fail")
+
+    monkeypatch.setattr("shared.cloud_ai.time.sleep", lambda _s: None)
+    with pytest.raises(RuntimeError):
+        provider._retry_on_failure(always_fail)
+
+
+def test_generate_text_updates_usage(monkeypatch):
+    provider = DummyCloud("dummy", requests_per_minute=1000000)
+    monkeypatch.setattr("shared.cloud_ai.time.sleep", lambda _s: None)
+
+    response = provider.generate_text([Message.user_text("hi")])
+    assert response.content == "ok"
+    assert provider.total_requests == 1
+    assert provider.total_tokens == 5
+    assert provider.total_cost == 0.1
+
+
+def test_generate_text_stream():
+    provider = DummyCloud("dummy")
+    provider.stream_chunks = ["a", "b"]
+    chunks = list(provider.generate_text_stream([Message.user_text("hi")]))
+    assert chunks == ["a", "b"]
+
+
+def test_reset_usage_stats():
+    provider = DummyCloud("dummy")
+    provider.total_requests = 5
+    provider.total_tokens = 9
+    provider.total_cost = 1.2
+    provider.reset_usage_stats()
+    assert provider.total_requests == 0
+    assert provider.total_tokens == 0
+    assert provider.total_cost == 0.0

--- a/givephotobankreadymediafiles/tests/unit/test_shared_config__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_shared_config__scenarios.py
@@ -1,0 +1,46 @@
+"""
+Unit tests for givephotobankreadymediafiles/shared/config.py.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+import shared.config as config_module
+
+
+def test_get_ai_api_key__env(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "key")
+    cfg = config_module.Config.__new__(config_module.Config)
+    cfg.config_data = {}
+    assert cfg.get_ai_api_key("openai") == "key"
+
+
+def test_get_available_ai_models__filters_missing_keys(monkeypatch):
+    cfg = config_module.Config.__new__(config_module.Config)
+    cfg.config_data = {
+        "ai_providers": {
+            "openai": {
+                "name": "OpenAI",
+                "models": {"gpt": {"name": "GPT", "supports_images": True}},
+                "api_key": "file_key",
+            }
+        }
+    }
+    monkeypatch.setattr(cfg, "get_ai_api_key", lambda _p: "k")
+    models = cfg.get_available_ai_models()
+    assert models[0]["provider"] == "openai"
+
+
+def test_get_default_ai_model__fallback():
+    cfg = config_module.Config.__new__(config_module.Config)
+    cfg.config_data = {"defaults": {"ai_provider": "openai", "ai_model": "gpt"}}
+    cfg.get_ai_model_config = lambda *_a, **_k: None
+    cfg.get_available_ai_models = lambda: []
+    assert cfg.get_default_ai_model() == ("openai", "gpt")

--- a/givephotobankreadymediafiles/tests/unit/test_shared_exif_downloader__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_shared_exif_downloader__scenarios.py
@@ -1,0 +1,29 @@
+"""
+Unit tests for givephotobankreadymediafiles/shared/exif_downloader.py.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+import shared.exif_downloader as exif_downloader
+
+
+def test_ensure_exiftool__returns_path_when_exists(monkeypatch):
+    monkeypatch.setattr(exif_downloader, "EXIFTOOL_PATH", "C:/Tools/exiftool.exe")
+    monkeypatch.setattr(exif_downloader.os.path, "exists", lambda _p: True)
+
+    assert exif_downloader.ensure_exiftool() == "C:/Tools/exiftool.exe"
+
+
+def test_ensure_exiftool__raises_when_missing(monkeypatch):
+    monkeypatch.setattr(exif_downloader, "EXIFTOOL_PATH", "C:/Tools/exiftool.exe")
+    monkeypatch.setattr(exif_downloader.os.path, "exists", lambda _p: False)
+
+    with pytest.raises(FileNotFoundError):
+        exif_downloader.ensure_exiftool()

--- a/givephotobankreadymediafiles/tests/unit/test_shared_exif_handler__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_shared_exif_handler__scenarios.py
@@ -1,0 +1,24 @@
+"""
+Unit tests for givephotobankreadymediafiles/shared/exif_handler.py.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+import shared.exif_handler as exif_handler
+
+
+def test_update_exif_metadata__raises_when_missing(monkeypatch):
+    monkeypatch.setattr(exif_handler.shutil, "which", lambda _n: None)
+    monkeypatch.setattr(exif_handler.os.path, "isdir", lambda _p: False)
+    monkeypatch.setattr(exif_handler.os.path, "isfile", lambda _p: False)
+    monkeypatch.setattr(exif_handler.os, "access", lambda _p, _m: False)
+
+    with pytest.raises(RuntimeError):
+        exif_handler.update_exif_metadata("C:/media/file.jpg", {}, tool_path=None)

--- a/givephotobankreadymediafiles/tests/unit/test_shared_file_operations__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_shared_file_operations__scenarios.py
@@ -1,0 +1,72 @@
+"""
+Unit tests for givephotobankreadymediafiles/shared/file_operations.py.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+import shared.file_operations as file_ops
+
+
+class DummyTqdm:
+    def __init__(self, iterable=None, total=None, desc=None, unit=None):
+        self.iterable = iterable
+
+    def __iter__(self):
+        return iter(self.iterable or [])
+
+
+@pytest.fixture
+def patch_tqdm(monkeypatch):
+    monkeypatch.setattr(file_ops, "tqdm", DummyTqdm)
+
+
+def test_list_files__recursive(tmp_path):
+    (tmp_path / "a.txt").write_text("a", encoding="utf-8")
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    (nested / "b.txt").write_text("b", encoding="utf-8")
+
+    files = file_ops.list_files(str(tmp_path), recursive=True)
+
+    assert any("a.txt" in f for f in files)
+    assert any("b.txt" in f for f in files)
+
+
+def test_copy_file__creates_dest_dir(tmp_path):
+    src = tmp_path / "src.txt"
+    src.write_text("x", encoding="utf-8")
+    dest = tmp_path / "out" / "dest.txt"
+
+    file_ops.copy_file(str(src), str(dest), overwrite=True)
+
+    assert dest.exists()
+
+
+def test_load_csv__header_only(tmp_path, patch_tqdm):
+    csv_path = tmp_path / "data.csv"
+    csv_path.write_text("A,B\n", encoding="utf-8")
+
+    records = file_ops.load_csv(str(csv_path))
+
+    assert records == []
+
+
+def test_read_write_text(tmp_path):
+    target = tmp_path / "note.txt"
+    file_ops.write_text(str(target), "hello")
+
+    assert file_ops.read_text(str(target)) == "hello"
+
+
+def test_write_json_and_read_json(tmp_path):
+    target = tmp_path / "data.json"
+    file_ops.write_json(str(target), {"a": 1})
+
+    assert file_ops.read_json(str(target)) == {"a": 1}

--- a/givephotobankreadymediafiles/tests/unit/test_shared_hash_utils__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_shared_hash_utils__scenarios.py
@@ -1,0 +1,21 @@
+"""
+Unit tests for givephotobankreadymediafiles/shared/hash_utils.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+import shared.hash_utils as hash_utils
+
+
+def test_compute_file_hash__md5(tmp_path):
+    data_file = tmp_path / "data.bin"
+    data_file.write_bytes(b"abc")
+
+    result = hash_utils.compute_file_hash(str(data_file), method="md5")
+
+    assert len(result) == 32

--- a/givephotobankreadymediafiles/tests/unit/test_shared_local_ai__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_shared_local_ai__scenarios.py
@@ -1,0 +1,96 @@
+"""
+Unit tests for givephotobankreadymediafiles/shared/local_ai.py.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+from shared.ai_provider import AIResponse, Message
+from shared.local_ai import LocalAIProvider
+
+
+class DummyLocal(LocalAIProvider):
+    def __init__(self, model_name, **kwargs):
+        super().__init__(model_name, **kwargs)
+        self.loaded = 0
+        self.unloaded = 0
+        self.last_gen_kwargs = None
+
+    def _load_model(self):
+        self.loaded += 1
+        self.model = "model"
+        self.tokenizer = "tok"
+
+    def _unload_model(self):
+        self.unloaded += 1
+
+    def _generate_response(self, messages, **kwargs):
+        self.last_gen_kwargs = kwargs
+        if messages[0].content == "bad":
+            raise ValueError("bad")
+        return AIResponse(
+            content="ok",
+            model=self.model_name,
+            usage={"total_tokens": 7},
+        )
+
+
+def test_load_and_unload_model():
+    provider = DummyLocal("dummy")
+    assert provider.is_loaded is False
+    provider.load_model()
+    assert provider.is_loaded is True
+    assert provider.loaded == 1
+    provider.unload_model()
+    assert provider.is_loaded is False
+    assert provider.unloaded == 1
+    assert provider.model is None
+
+
+def test_generate_text_merges_kwargs():
+    provider = DummyLocal("dummy", max_new_tokens=10, temperature=0.1)
+    response = provider.generate_text([Message.user_text("hi")], top_p=0.2)
+    assert response.content == "ok"
+    assert provider.last_gen_kwargs["max_new_tokens"] == 10
+    assert provider.last_gen_kwargs["temperature"] == 0.1
+    assert provider.last_gen_kwargs["top_p"] == 0.2
+    assert provider.total_generations == 1
+    assert provider.total_tokens_generated == 7
+
+
+def test_create_batch_job_handles_errors():
+    provider = DummyLocal("dummy")
+    messages_list = [
+        [Message.user_text("ok")],
+        [Message.user_text("bad")],
+    ]
+    job = provider.create_batch_job(messages_list, ["a", "b"])
+    assert job.status == "completed"
+    assert job.results[0].content == "ok"
+    assert "Error:" in job.results[1].content
+
+
+def test_local_batch_job_not_supported():
+    provider = DummyLocal("dummy")
+    with pytest.raises(NotImplementedError):
+        provider.get_batch_job("job")
+    assert provider.cancel_batch_job("job") is False
+
+
+def test_supports_batch_and_usage_stats():
+    provider = DummyLocal("dummy")
+    assert provider.supports_batch() is True
+    stats = provider.get_usage_stats()
+    assert stats["model"] == "dummy"
+
+
+def test_get_model_info_includes_type():
+    provider = DummyLocal("dummy")
+    info = provider.get_model_info()
+    assert info["type"] == "local"

--- a/givephotobankreadymediafiles/tests/unit/test_shared_logging_config__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_shared_logging_config__scenarios.py
@@ -1,0 +1,88 @@
+"""
+Unit tests for givephotobankreadymediafiles/shared/logging_config.py.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+import shared.logging_config as logging_config
+
+
+class DummyHandler:
+    def __init__(self, *_args, **_kwargs):
+        self.formatter = None
+
+    def setFormatter(self, formatter):
+        self.formatter = formatter
+
+
+class DummyLogger:
+    def __init__(self):
+        self.handlers = [DummyHandler()]
+        self.level = None
+
+    def setLevel(self, level):
+        self.level = level
+
+    def addHandler(self, handler):
+        self.handlers.append(handler)
+
+    def removeHandler(self, handler):
+        self.handlers.remove(handler)
+
+
+class DummyFormatter:
+    def __init__(self, *_args, **_kwargs):
+        return None
+
+
+def test_setup_logging__missing_config_raises(monkeypatch):
+    def fail_open(*_args, **_kwargs):
+        raise OSError("missing")
+
+    monkeypatch.setattr(logging_config, "open", fail_open)
+
+    with pytest.raises(Exception):
+        logging_config.setup_logging()
+
+
+def test_setup_logging__sets_level_and_handlers(monkeypatch):
+    dummy_logger = DummyLogger()
+
+    monkeypatch.setattr(logging_config.logging, "getLogger", lambda: dummy_logger)
+    monkeypatch.setattr(logging_config.logging, "StreamHandler", DummyHandler)
+    monkeypatch.setattr(logging_config.logging, "FileHandler", DummyHandler)
+    monkeypatch.setattr(logging_config.colorlog, "ColoredFormatter", DummyFormatter)
+
+    def fake_open(*_args, **_kwargs):
+        class DummyFile:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return '{"DEBUG": "white", "INFO": "green", "WARNING": "yellow", "ERROR": "red", "CRITICAL": "red"}'
+
+        return DummyFile()
+
+    monkeypatch.setattr(logging_config, "open", fake_open)
+    monkeypatch.setattr(logging_config.json, "load", lambda _f: {
+        "DEBUG": "white",
+        "INFO": "green",
+        "WARNING": "yellow",
+        "ERROR": "red",
+        "CRITICAL": "red",
+    })
+
+    logging_config.setup_logging(debug=False, log_file="C:/logs/test.log")
+
+    assert dummy_logger.level == logging_config.logging.INFO
+    assert len(dummy_logger.handlers) == 2

--- a/givephotobankreadymediafiles/tests/unit/test_shared_module_imports__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_shared_module_imports__scenarios.py
@@ -1,0 +1,46 @@
+"""
+Import smoke tests for shared modules with external dependencies.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+
+def test_import_ai_module():
+    import shared.ai_module  # noqa: F401
+
+
+def test_import_cloud_ai():
+    import shared.cloud_ai  # noqa: F401
+
+
+def test_import_local_ai():
+    import shared.local_ai  # noqa: F401
+
+
+def test_import_neural_network():
+    import shared.neural_network  # noqa: F401
+
+
+def test_import_openai_provider():
+    import shared.openai_provider  # noqa: F401
+
+
+def test_import_anthropic_provider():
+    import shared.anthropic_provider  # noqa: F401
+
+
+def test_import_ollama_provider():
+    import shared.ollama_provider  # noqa: F401
+
+
+def test_import_prompt_manager():
+    import shared.prompt_manager  # noqa: F401
+
+
+def test_import_config():
+    import shared.config  # noqa: F401

--- a/givephotobankreadymediafiles/tests/unit/test_shared_neural_network__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_shared_neural_network__scenarios.py
@@ -1,0 +1,86 @@
+"""
+Unit tests for givephotobankreadymediafiles/shared/neural_network.py.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+from shared.ai_provider import AIResponse, Message
+from shared.neural_network import NeuralNetworkProvider
+
+
+class DummyModel:
+    def __init__(self):
+        self.evaluated = False
+
+    def eval(self):
+        self.evaluated = True
+
+
+class DummyNN(NeuralNetworkProvider):
+    def __init__(self, model_name, model_config, **kwargs):
+        super().__init__(model_name, model_config, **kwargs)
+        self.loaded_checkpoint = None
+        self.saved_checkpoint = None
+
+    def _build_model(self):
+        return DummyModel()
+
+    def _load_checkpoint(self, checkpoint_path):
+        self.loaded_checkpoint = checkpoint_path
+
+    def _save_checkpoint(self, checkpoint_path):
+        self.saved_checkpoint = checkpoint_path
+
+    def _preprocess_messages(self, messages):
+        return {"count": len(messages)}
+
+    def _postprocess_output(self, model_output):
+        return f"processed-{model_output}"
+
+    def _forward_pass(self, input_data, **kwargs):
+        return "output"
+
+
+def test_load_model_with_checkpoint(tmp_path):
+    checkpoint = tmp_path / "ckpt.bin"
+    checkpoint.write_text("data", encoding="utf-8")
+    provider = DummyNN("dummy", {"supports_images": True}, checkpoint_path=str(checkpoint))
+    provider.load_model()
+    assert provider.is_loaded is True
+    assert provider.loaded_checkpoint == str(checkpoint)
+    assert provider.model.evaluated is True
+
+
+def test_generate_text_updates_stats():
+    provider = DummyNN("dummy", {}, framework="tensorflow")
+    response = provider.generate_text([Message.user_text("hi")])
+    assert response.content == "processed-output"
+    assert provider.total_inferences == 1
+    assert provider.average_inference_time > 0
+
+
+def test_save_model_requires_loaded(tmp_path):
+    provider = DummyNN("dummy", {})
+    with pytest.raises(RuntimeError):
+        provider.save_model(str(tmp_path / "model.bin"))
+
+    provider.load_model()
+    target = tmp_path / "subdir" / "model.bin"
+    provider.save_model(str(target))
+    assert provider.saved_checkpoint == str(target)
+
+
+def test_supports_images_and_batch_job():
+    provider = DummyNN("dummy", {"supports_images": False})
+    assert provider.supports_images() is False
+    job = provider.create_batch_job([[Message.user_text("a")]], ["id"])
+    assert job.status == "completed"
+    assert job.results[0].content == "processed-output"
+    assert provider.supports_streaming() is False

--- a/givephotobankreadymediafiles/tests/unit/test_shared_ollama_provider__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_shared_ollama_provider__scenarios.py
@@ -1,0 +1,169 @@
+"""
+Unit tests for givephotobankreadymediafiles/shared/ollama_provider.py.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+from shared.ai_provider import ContentBlock, Message, MessageRole
+from shared.ollama_provider import OllamaProvider
+
+
+class DummyResponse:
+    def __init__(self, status_code=200, payload=None, lines=None):
+        self.status_code = status_code
+        self._payload = payload or {}
+        self._lines = lines or []
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError("bad")
+
+    def json(self):
+        return self._payload
+
+    def iter_lines(self):
+        return self._lines
+
+
+class DummySession:
+    def __init__(self):
+        self.get_calls = []
+        self.post_calls = []
+        self.responses = {}
+
+    def get(self, url, timeout=None):
+        self.get_calls.append((url, timeout))
+        return self.responses.get(("GET", url), DummyResponse(status_code=404))
+
+    def post(self, url, json=None, timeout=None, stream=False):
+        self.post_calls.append((url, json, timeout, stream))
+        return self.responses.get(("POST", url), DummyResponse(status_code=404))
+
+    def close(self):
+        pass
+
+
+def test_convert_messages_and_options():
+    provider = OllamaProvider("llava")
+    provider.session = DummySession()
+    messages = [
+        Message.user_text("hi"),
+        Message(
+            role=MessageRole.USER,
+            content=[
+                ContentBlock.text("t"),
+                ContentBlock.image_base64("AAA"),
+                ContentBlock.image_url("http://img"),
+            ],
+        ),
+    ]
+    converted = provider._convert_messages_to_ollama_format(messages)
+    assert converted[0]["content"] == "hi"
+    assert converted[1]["content"] == "t"
+    assert converted[1]["images"] == ["AAA"]
+
+    options = provider._prepare_generation_options(num_predict=10, stop=["x"])
+    assert options["num_predict"] == 10
+    assert options["stop"] == ["x"]
+
+
+def test_check_server_available():
+    provider = OllamaProvider("llava")
+    session = DummySession()
+    provider.session = session
+    session.responses[("GET", f"{provider.base_url}/api/tags")] = DummyResponse(status_code=200)
+    assert provider._check_server_available() is True
+
+
+def test_simple_and_chat_generation():
+    provider = OllamaProvider("llava")
+    session = DummySession()
+    provider.session = session
+
+    session.responses[("GET", f"{provider.base_url}/api/tags")] = DummyResponse(status_code=200)
+    session.responses[("POST", f"{provider.base_url}/api/chat")] = DummyResponse(
+        payload={
+            "message": {"content": "chat"},
+            "prompt_eval_count": 1,
+            "eval_count": 2,
+        }
+    )
+    session.responses[("POST", f"{provider.base_url}/api/generate")] = DummyResponse(
+        payload={
+            "response": "simple",
+            "prompt_eval_count": 1,
+            "eval_count": 1,
+        }
+    )
+
+    chat_response = provider._generate_response([Message.user_text("hi"), Message.user_text("there")])
+    assert chat_response.content == "chat"
+
+    simple_response = provider._generate_response([Message.user_text("hi")])
+    assert simple_response.content == "simple"
+
+
+def test_streaming_generation():
+    provider = OllamaProvider("llava")
+    session = DummySession()
+    provider.session = session
+
+    session.responses[("GET", f"{provider.base_url}/api/tags")] = DummyResponse(status_code=200)
+    chat_lines = [
+        json.dumps({"message": {"content": "a"}}).encode("utf-8"),
+        json.dumps({"message": {"content": "b"}, "done": True}).encode("utf-8"),
+    ]
+    session.responses[("POST", f"{provider.base_url}/api/chat")] = DummyResponse(lines=chat_lines)
+
+    chunks = list(provider.generate_text_stream([Message.user_text("hi"), Message.user_text("there")]))
+    assert chunks == ["a", "b"]
+
+
+def test_get_available_models_and_pull():
+    provider = OllamaProvider("llava")
+    session = DummySession()
+    provider.session = session
+
+    session.responses[("GET", f"{provider.base_url}/api/tags")] = DummyResponse(
+        status_code=200, payload={"models": [{"name": "m1"}, {"name": "m2"}]}
+    )
+    models = provider.get_available_models()
+    assert models == ["m1", "m2"]
+
+    pull_lines = [json.dumps({"status": "downloading"}).encode("utf-8")]
+    session.responses[("POST", f"{provider.base_url}/api/pull")] = DummyResponse(lines=pull_lines)
+    assert provider.pull_model("m1") is True
+
+
+def test_server_unavailable_paths():
+    provider = OllamaProvider("llava")
+    session = DummySession()
+    provider.session = session
+
+    assert provider._check_server_available() is False
+    assert provider.get_available_models() == []
+
+    with pytest.raises(RuntimeError):
+        provider._generate_response([Message.user_text("hi")])
+
+    with pytest.raises(RuntimeError):
+        list(provider.generate_text_stream([Message.user_text("hi")]))
+
+
+def test_supports_images_and_model_info():
+    provider = OllamaProvider("llava:7b")
+    session = DummySession()
+    provider.session = session
+    assert provider.supports_images() is True
+
+    session.responses[("GET", f"{provider.base_url}/api/tags")] = DummyResponse(status_code=404)
+    info = provider.get_model_info()
+    assert info["type"] == "ollama"

--- a/givephotobankreadymediafiles/tests/unit/test_shared_openai_provider__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_shared_openai_provider__scenarios.py
@@ -1,0 +1,249 @@
+"""
+Unit tests for givephotobankreadymediafiles/shared/openai_provider.py.
+"""
+
+import io
+import json
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+from shared.ai_provider import ContentBlock, Message, MessageRole
+from shared.openai_provider import OpenAIProvider
+
+
+class DummyChoice:
+    def __init__(self, content, finish_reason):
+        self.message = type("msg", (), {"content": content})
+        self.finish_reason = finish_reason
+
+
+class DummyUsage:
+    def __init__(self, prompt, completion, total):
+        self.prompt_tokens = prompt
+        self.completion_tokens = completion
+        self.total_tokens = total
+
+
+class DummyResponse:
+    def __init__(self):
+        self.id = "resp"
+        self.model = "gpt-4o"
+        self.created = 123
+        self.choices = [DummyChoice("hello", "stop")]
+        self.usage = DummyUsage(1, 2, 3)
+
+
+class DummyCompletions:
+    def __init__(self, response):
+        self._response = response
+        self.last_kwargs = None
+
+    def create(self, **kwargs):
+        self.last_kwargs = kwargs
+        return self._response
+
+
+class DummyChat:
+    def __init__(self, response):
+        self.completions = DummyCompletions(response)
+
+
+class DummyFiles:
+    def __init__(self, file_id):
+        self.file_id = file_id
+        self.content_value = None
+
+    def create(self, file, purpose):
+        return type("obj", (), {"id": self.file_id})
+
+    def content(self, file_id):
+        return self.content_value
+
+
+class DummyBatches:
+    def __init__(self):
+        self.created = None
+        self.retrieve_value = None
+        self.cancelled = []
+
+    def create(self, **kwargs):
+        self.created = kwargs
+        return type(
+            "obj",
+            (),
+            {
+                "id": "batch1",
+                "status": "validating",
+                "created_at": 10,
+                "endpoint": "/v1/chat/completions",
+                "completion_window": "24h",
+            },
+        )
+
+    def retrieve(self, job_id):
+        return self.retrieve_value
+
+    def cancel(self, job_id):
+        self.cancelled.append(job_id)
+
+
+class DummyClient:
+    def __init__(self):
+        self.chat = DummyChat(DummyResponse())
+        self.files = DummyFiles("file1")
+        self.batches = DummyBatches()
+
+
+def test_convert_messages_text_and_images():
+    provider = OpenAIProvider("gpt-4o")
+    messages = [
+        Message.user_text("hi"),
+        Message(
+            role=MessageRole.USER,
+            content=[
+                ContentBlock.text("t"),
+                ContentBlock.image_url("http://img"),
+                ContentBlock.image_base64("AAA", metadata={"mime_type": "image/png"}),
+            ],
+        ),
+    ]
+    converted = provider._convert_messages(messages)
+    assert converted[0]["content"] == "hi"
+    assert converted[1]["content"][1]["type"] == "image_url"
+    assert "data:image/png;base64,AAA" in converted[1]["content"][2]["image_url"]["url"]
+
+
+def test_make_request_and_supports_images(monkeypatch):
+    provider = OpenAIProvider("gpt-4o")
+    provider._client = DummyClient()
+
+    response = provider._make_request([Message.user_text("hi")])
+    assert response.content == "hello"
+
+    provider.model_name = "gpt-5-nano"
+    assert provider.supports_images() is False
+    provider.model_name = "gpt-4o"
+    assert provider.supports_images() is True
+
+
+def test_calculate_cost():
+    provider = OpenAIProvider("gpt-4o")
+    cost = provider._calculate_cost({"prompt_tokens": 1000, "completion_tokens": 1000})
+    assert cost > 0
+    provider.model_name = "unknown"
+    assert provider._calculate_cost({"prompt_tokens": 1000, "completion_tokens": 1000}) == 0.0
+
+
+def test_create_batch_job_and_cleanup(monkeypatch, tmp_path):
+    provider = OpenAIProvider("gpt-4o")
+    provider._client = DummyClient()
+
+    written = {}
+    deleted = {}
+
+    def fake_write_text(path, content):
+        written["path"] = path
+        written["content"] = content
+
+    @contextmanager
+    def fake_open_file_handle(path, mode):
+        yield io.BytesIO(b"data")
+
+    def fake_delete_file(path):
+        deleted["path"] = path
+
+    monkeypatch.setattr("shared.openai_provider.write_text", fake_write_text)
+    monkeypatch.setattr("shared.openai_provider.open_file_handle", fake_open_file_handle)
+    monkeypatch.setattr("shared.openai_provider.delete_file", fake_delete_file)
+
+    job = provider.create_batch_job([[Message.user_text("hi")]], ["id1"])
+    assert job.job_id == "batch1"
+    assert "id1" in written["content"]
+    assert deleted["path"]
+
+
+def test_get_batch_job_parses_results():
+    provider = OpenAIProvider("gpt-4o")
+    provider._client = DummyClient()
+
+    result_line = json.dumps(
+        {
+            "custom_id": "x",
+            "response": {
+                "body": {
+                    "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+                    "model": "gpt-4o",
+                    "usage": {"total_tokens": 3},
+                }
+            },
+        }
+    )
+
+    file_content = type(
+        "obj",
+        (),
+        {"iter_lines": lambda self: [result_line.encode("utf-8")]},
+    )()
+
+    provider._client.files.content_value = file_content
+    provider._client.batches.retrieve_value = type(
+        "obj",
+        (),
+        {
+            "status": "completed",
+            "created_at": 10,
+            "completed_at": 20,
+            "input_file_id": "in",
+            "output_file_id": "out",
+            "error_file_id": None,
+            "request_counts": None,
+        },
+    )
+
+    job = provider.get_batch_job("job")
+    assert job.status == "completed"
+    assert job.results[0].content == "ok"
+
+
+def test_cancel_batch_job():
+    provider = OpenAIProvider("gpt-4o")
+    provider._client = DummyClient()
+    assert provider.cancel_batch_job("job") is True
+
+
+def test_cancel_batch_job_failure():
+    provider = OpenAIProvider("gpt-4o")
+    client = DummyClient()
+
+    def raise_error(_job_id):
+        raise RuntimeError("fail")
+
+    client.batches.cancel = raise_error
+    provider._client = client
+    assert provider.cancel_batch_job("job") is False
+
+
+def test_make_stream_request():
+    provider = OpenAIProvider("gpt-4o")
+
+    class DummyDelta:
+        def __init__(self, content):
+            self.content = content
+
+    class DummyChunk:
+        def __init__(self, content):
+            self.choices = [type("choice", (), {"delta": DummyDelta(content)})()]
+
+    client = DummyClient()
+    client.chat.completions.create = lambda **kwargs: [DummyChunk("a"), DummyChunk("b")]
+    provider._client = client
+
+    chunks = list(provider._make_stream_request([Message.user_text("hi")]))
+    assert chunks == ["a", "b"]

--- a/givephotobankreadymediafiles/tests/unit/test_shared_prompt_manager__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_shared_prompt_manager__scenarios.py
@@ -1,0 +1,145 @@
+"""
+Unit tests for givephotobankreadymediafiles/shared/prompt_manager.py.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+from shared.prompt_manager import PromptManager, get_prompt_manager
+
+
+def _write_config(path: Path):
+    config = {
+        "metadata_generation": {
+            "title": {
+                "variables": {"prefix": "Title"},
+                "template": ["{prefix}", "{user_input_section}", "{context_section}"],
+                "user_input_template": "User: {user_description}",
+                "context_template": "Context: {context}",
+            },
+            "description": {
+                "variables": {"prefix": "Desc"},
+                "template": "{prefix}\n{user_input_section}\n{title_section}\n{context_section}",
+                "user_input_template": "User: {user_description}",
+                "title_template": "Title: {title}",
+                "context_template": "Context: {context}",
+            },
+            "keywords": {
+                "variables": {"prefix": "Keys"},
+                "template": "{prefix}\n{title_section}\n{description_section}\nCount: {count}",
+                "title_template": "Title: {title}",
+                "description_template": "Description: {description}",
+            },
+            "categories": {
+                "variables": {"prefix": "Cats"},
+                "template": "{prefix} {category_word}{category_plural} {max_categories} {photobank}\n{categories_list}\n{title_section}\n{description_section}",
+                "title_template": "Title: {title}",
+                "description_template": "Description: {description}",
+            },
+            "editorial": {
+                "variables": {"prefix": "Editorial"},
+                "template": "{prefix}\n{title_section}\n{description_section}",
+                "title_template": "Title: {title}",
+                "description_template": "Description: {description}",
+            },
+            "title_alternative": {
+                "variables": {"prefix": "AltTitle"},
+                "template": "{prefix}\n{original_title}\n{edit_tag}\n{edit_instructions}",
+            },
+            "description_alternative": {
+                "variables": {"prefix": "AltDesc"},
+                "template": "{prefix}\n{original_title}\n{original_description}\n{edit_instructions}",
+            },
+            "keywords_alternative": {
+                "variables": {"prefix": "AltKeys"},
+                "template": "{prefix}\n{original_keywords}\n{count}",
+            },
+        },
+        "character_limits": {"title": 50, "description": 100, "keywords_max": 30},
+        "photobank_limits": {"adobestock": 1, "dreamstime": 3},
+    }
+    path.write_text(json.dumps(config), encoding="utf-8")
+
+
+def test_prompt_manager_title_and_description(tmp_path):
+    config_path = tmp_path / "prompts.json"
+    _write_config(config_path)
+
+    manager = PromptManager(str(config_path))
+    title_prompt = manager.get_title_prompt(context="Old", user_description="Note")
+    assert "Title" in title_prompt
+    assert "User: Note" in title_prompt
+    assert "Context: Old" in title_prompt
+
+    description_prompt = manager.get_description_prompt(
+        title="Hello", context=None, user_description="Note"
+    )
+    assert "Title: Hello" in description_prompt
+    assert "Context:" not in description_prompt
+
+
+def test_prompt_manager_keywords_and_categories(tmp_path):
+    config_path = tmp_path / "prompts.json"
+    _write_config(config_path)
+
+    manager = PromptManager(str(config_path))
+    keywords_prompt = manager.get_keywords_prompt(title="T", description="D", count=5)
+    assert "Count: 5" in keywords_prompt
+
+    categories_prompt = manager.get_categories_prompt(
+        photobank="Adobe Stock",
+        categories=["A", "B"],
+        title="T",
+        description="D",
+    )
+    assert "y 1 adobestock" in categories_prompt
+    assert "A, B" in categories_prompt
+
+
+def test_prompt_manager_editorial_and_alternatives(tmp_path):
+    config_path = tmp_path / "prompts.json"
+    _write_config(config_path)
+
+    manager = PromptManager(str(config_path))
+    editorial_prompt = manager.get_editorial_prompt(title="T", description="D")
+    assert "Editorial" in editorial_prompt
+
+    title_alt = manager.get_title_alternative_prompt("_bw", "Original")
+    assert "AltTitle" in title_alt
+
+    desc_alt = manager.get_description_alternative_prompt("_bw", "Original", "Desc")
+    assert "AltDesc" in desc_alt
+
+    keywords_alt = manager.get_keywords_alternative_prompt(
+        "_bw",
+        "Original",
+        "Desc",
+        [f"k{i}" for i in range(12)],
+        count=11,
+    )
+    assert "AltKeys" in keywords_alt
+    assert "... (12 total)" in keywords_alt
+
+
+def test_prompt_manager_limits_and_fallbacks(tmp_path):
+    config_path = tmp_path / "missing.json"
+    manager = PromptManager(str(config_path))
+
+    title_prompt = manager.get_title_prompt()
+    assert "Return ONLY the title" in title_prompt
+
+    assert manager.get_character_limits()["title"] == 100
+    assert manager.get_photobank_limits()["adobestock"] == 1
+
+
+def test_prompt_manager_global_instance():
+    first = get_prompt_manager()
+    second = get_prompt_manager()
+    assert first is second

--- a/givephotobankreadymediafiles/tests/unit/test_shared_utils__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_shared_utils__scenarios.py
@@ -1,0 +1,35 @@
+"""
+Unit tests for givephotobankreadymediafiles/shared/utils.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+import shared.utils as utils
+
+
+def test_get_script_name__basename(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["C:/tools/run_me.py"])
+    assert utils.get_script_name() == "run_me"
+
+
+def test_get_log_filename__format(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["C:/tools/run_me.py"])
+
+    class DummyDateTime:
+        @classmethod
+        def now(cls):
+            class Dummy:
+                def strftime(self, _fmt):
+                    return "2020-01-01_12-00-00"
+
+            return Dummy()
+
+    monkeypatch.setattr(utils, "datetime", DummyDateTime)
+
+    result = utils.get_log_filename("C:/logs")
+    assert result.endswith("run_me_Log_2020-01-01_12-00-00.log")

--- a/givephotobankreadymediafiles/tests/unit/test_tag_entry__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_tag_entry__scenarios.py
@@ -1,0 +1,234 @@
+"""
+Unit tests for givephotobankreadymediafileslib/tag_entry.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+from givephotobankreadymediafileslib import tag_entry
+
+
+class DummyButton:
+    def __init__(self):
+        self.state = "disabled"
+        self.text = None
+        self.command = None
+
+    def configure(self, **kwargs):
+        if "state" in kwargs:
+            self.state = kwargs["state"]
+        if "text" in kwargs:
+            self.text = kwargs["text"]
+        if "command" in kwargs:
+            self.command = kwargs["command"]
+
+
+class DummyLabel:
+    def __init__(self):
+        self.text = None
+        self.foreground = None
+
+    def configure(self, **kwargs):
+        self.text = kwargs.get("text", self.text)
+        self.foreground = kwargs.get("foreground", self.foreground)
+
+
+class DummyEntry:
+    def __init__(self):
+        self.text = ""
+        self.state = "disabled"
+        self.focused = False
+
+    def configure(self, state=None):
+        if state is not None:
+            self.state = state
+
+    def delete(self, *_args):
+        self.text = ""
+
+    def insert(self, _index, value):
+        self.text = value
+
+    def get(self):
+        return self.text
+
+    def focus(self):
+        self.focused = True
+
+    def select_range(self, *_args):
+        return None
+
+    def __getitem__(self, key):
+        if key == "state":
+            return self.state
+        raise KeyError(key)
+
+
+class DummyListbox:
+    def __init__(self):
+        self.items = []
+        self.selection = ()
+        self._nearest = 0
+
+    def curselection(self):
+        return self.selection
+
+    def selection_clear(self, *_args):
+        self.selection = ()
+
+    def selection_set(self, index):
+        self.selection = (index,)
+
+    def delete(self, *_args):
+        self.items = []
+
+    def insert(self, _pos, text):
+        self.items.append(text)
+
+    def nearest(self, _y):
+        return self._nearest
+
+    def set_nearest(self, value):
+        self._nearest = value
+
+
+def _build_entry():
+    entry = tag_entry.TagEntry.__new__(tag_entry.TagEntry)
+    entry.max_tags = 5
+    entry.separators = set(",;")
+    entry.on_change = None
+    entry._tags = []
+    entry._edit_mode = False
+    entry._edit_index = None
+    entry.listbox = DummyListbox()
+    entry.entry = DummyEntry()
+    entry.up_button = DummyButton()
+    entry.down_button = DummyButton()
+    entry.top_button = DummyButton()
+    entry.bottom_button = DummyButton()
+    entry.edit_button = DummyButton()
+    entry.delete_button = DummyButton()
+    entry.clear_button = DummyButton()
+    entry.add_button = DummyButton()
+    entry.counter_label = DummyLabel()
+    return entry
+
+
+def test_update_button_states__selection():
+    entry = _build_entry()
+    entry._tags = ["a", "b"]
+    entry.listbox.selection_set(0)
+
+    entry.update_button_states()
+    assert entry.up_button.state == "disabled"
+    assert entry.down_button.state == "normal"
+    assert entry.clear_button.state == "normal"
+
+
+def test_add_and_remove_tags():
+    entry = _build_entry()
+    assert entry.add_tag("tag1") is True
+    assert entry.add_tag("ta") is True
+    assert entry.add_tag("ta") is False
+    assert entry.get_tags() == ["tag1", "ta"]
+
+    entry.listbox.selection_set(0)
+    entry.remove_selected_tags()
+    assert entry.get_tags() == ["ta"]
+
+
+def test_set_and_clear_tags():
+    entry = _build_entry()
+    entry.set_tags(["a", "bb", "ccc"])
+    assert entry.get_tags() == ["bb", "ccc"]
+
+    entry.clear_tags()
+    assert entry.get_tags() == []
+
+
+def test_focus__starts_add_mode():
+    entry = _build_entry()
+    entry.focus()
+    assert entry.entry.state == "normal"
+
+
+def test_get_set_text():
+    entry = _build_entry()
+    entry.set_text("one, two")
+    assert entry.get_text() == "one, two"
+
+    entry.set_text("")
+    assert entry.get_tags() == []
+
+
+def test_start_and_cancel_add_mode():
+    entry = _build_entry()
+    entry.start_add_mode()
+    assert entry.entry.state == "normal"
+    assert entry.add_button.text == "Confirm"
+
+    entry.cancel_entry_mode()
+    assert entry.entry.state == "disabled"
+    assert entry.add_button.text == "Add"
+
+
+def test_start_edit_mode_and_confirm():
+    entry = _build_entry()
+    entry._tags = ["first", "second"]
+    entry.listbox.selection_set(1)
+
+    entry.start_edit_mode()
+    assert entry._edit_mode is True
+    assert entry.entry.get() == "second"
+
+    entry.entry.text = "updated"
+    entry.confirm_edit()
+    assert entry._tags[1] == "updated"
+
+
+def test_confirm_add__multiple_tags():
+    entry = _build_entry()
+    entry.start_add_mode()
+    entry.entry.text = "alpha, beta; gamma"
+    entry.confirm_add()
+    assert entry.get_tags() == ["alpha", "beta", "gamma"]
+
+
+def test_move_up_down_top_bottom():
+    entry = _build_entry()
+    entry._tags = ["a", "b", "c"]
+    entry.listbox.selection_set(1)
+
+    entry.move_up()
+    assert entry._tags == ["b", "a", "c"]
+
+    entry.listbox.selection_set(1)
+    entry.move_down()
+    assert entry._tags == ["b", "c", "a"]
+
+    entry.listbox.selection_set(2)
+    entry.move_to_top()
+    assert entry._tags[0] == "a"
+
+    entry.listbox.selection_set(0)
+    entry.move_to_bottom()
+    assert entry._tags[-1] == "a"
+
+
+def test_on_click__cancels_entry_mode():
+    entry = _build_entry()
+    entry._tags = ["a", "b"]
+    entry.entry.state = "normal"
+
+    called = []
+    entry.cancel_entry_mode = lambda *_a, **_k: called.append(True)
+
+    entry.listbox.set_nearest(1)
+    entry.on_click(type("Evt", (), {"y": 0})())
+    assert called

--- a/givephotobankreadymediafiles/tests/unit/test_ui_components__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_ui_components__scenarios.py
@@ -1,0 +1,137 @@
+"""
+Unit tests for givephotobankreadymediafileslib/ui_components.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+from givephotobankreadymediafileslib import ui_components
+
+
+class DummyRoot:
+    def __init__(self):
+        self.after_calls = []
+        self.cancel_calls = []
+
+    def after(self, delay, callback):
+        self.after_calls.append((delay, callback))
+        return "timer-id"
+
+    def after_cancel(self, timer_id):
+        self.cancel_calls.append(timer_id)
+
+
+class DummyWidget:
+    def __init__(self, *args, **kwargs):
+        self.bound = []
+
+    def pack(self, *args, **kwargs):
+        return None
+
+    def add(self, *args, **kwargs):
+        return None
+
+    def bind(self, event, callback):
+        self.bound.append((event, callback))
+
+
+class DummyCombobox(DummyWidget):
+    pass
+
+
+class DummyButton(DummyWidget):
+    pass
+
+
+class DummyStyle:
+    def __init__(self):
+        self.configs = []
+
+    def configure(self, name, **kwargs):
+        self.configs.append((name, kwargs))
+
+
+class DummyTtk:
+    Style = DummyStyle
+    Frame = DummyWidget
+    Label = DummyWidget
+    Button = DummyButton
+    Combobox = DummyCombobox
+    PanedWindow = DummyWidget
+    LabelFrame = DummyWidget
+    Scale = DummyWidget
+    Checkbutton = DummyWidget
+
+
+def test_setup_styles__configures_styles(monkeypatch):
+    style = DummyStyle()
+
+    class LocalTtk(DummyTtk):
+        Style = lambda self=None: style
+
+    monkeypatch.setattr(ui_components, "ttk", LocalTtk)
+    ui = ui_components.UIComponents(root=DummyRoot())
+
+    ui.setup_styles()
+    assert style.configs
+
+
+def test_setup_ui__delegates(monkeypatch):
+    ui = ui_components.UIComponents(root=DummyRoot())
+    calls = []
+
+    monkeypatch.setattr(ui, "setup_media_panel", lambda *_a, **_k: calls.append("media"))
+    monkeypatch.setattr(ui, "setup_metadata_panel", lambda *_a, **_k: calls.append("meta"))
+
+    ui.setup_ui({}, {})
+    assert calls == ["media", "meta"]
+
+
+def test_setup_ai_model_panel__binds_selection(monkeypatch):
+    monkeypatch.setattr(ui_components, "ttk", DummyTtk)
+    ui = ui_components.UIComponents(root=DummyRoot())
+
+    def on_select(_evt=None):
+        return None
+
+    ui.setup_ai_model_panel(DummyWidget(), on_select)
+    assert isinstance(ui.model_combo, DummyCombobox)
+    assert ui.model_combo.bound
+
+
+def test_setup_categories_panel__creates_container(monkeypatch):
+    monkeypatch.setattr(ui_components, "ttk", DummyTtk)
+    ui = ui_components.UIComponents(root=DummyRoot())
+
+    ui.setup_categories_panel(DummyWidget(), lambda: None)
+    assert ui.categories_container is not None
+    assert ui.categories_generate_button is not None
+
+
+def test_update_all_button_states_debounced(monkeypatch):
+    root = DummyRoot()
+    ui = ui_components.UIComponents(root=root)
+
+    called = []
+    ui.set_button_update_callback(lambda: called.append(True))
+
+    ui.update_all_button_states_debounced()
+    assert root.after_calls
+
+    ui._button_update_timer = "timer-id"
+    ui.update_all_button_states_debounced()
+    assert root.cancel_calls == ["timer-id"]
+
+
+def test_set_button_update_callback():
+    ui = ui_components.UIComponents(root=DummyRoot())
+    callback = lambda: None
+    ui.set_button_update_callback(callback)
+    assert ui._button_update_callback is callback

--- a/givephotobankreadymediafiles/tests/unit/test_viewer_state__scenarios.py
+++ b/givephotobankreadymediafiles/tests/unit/test_viewer_state__scenarios.py
@@ -1,0 +1,161 @@
+"""
+Unit tests for givephotobankreadymediafileslib/viewer_state.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "givephotobankreadymediafiles"
+sys.path.insert(0, str(package_root))
+
+from givephotobankreadymediafileslib import viewer_state
+from givephotobankreadymediafileslib import constants
+
+
+class DummyEntry:
+    def __init__(self, value=""):
+        self.value = value
+
+    def get(self):
+        return self.value
+
+    def delete(self, *_args):
+        self.value = ""
+
+    def insert(self, _index, value):
+        self.value = value
+
+
+class DummyText:
+    def __init__(self, value=""):
+        self.value = value
+        self.focused = False
+
+    def get(self, *_args):
+        return self.value
+
+    def delete(self, *_args):
+        self.value = ""
+
+    def insert(self, _index, value):
+        self.value = value
+
+    def focus(self):
+        self.focused = True
+
+
+class DummyLabel:
+    def __init__(self):
+        self.text = None
+        self.foreground = None
+
+    def configure(self, **kwargs):
+        self.text = kwargs.get("text", self.text)
+        self.foreground = kwargs.get("foreground", self.foreground)
+
+
+class DummyVar:
+    def __init__(self):
+        self.value = None
+
+    def set(self, value):
+        self.value = value
+
+    def get(self):
+        return self.value
+
+
+class DummyTagEntry:
+    def __init__(self, tags=None):
+        self.tags = tags or []
+        self.set_calls = []
+
+    def get_tags(self):
+        return self.tags
+
+    def set_tags(self, tags):
+        self.set_calls.append(tags)
+
+
+def test_on_title_change__truncates_and_colors():
+    state = viewer_state.ViewerState(root=object())
+    state.title_entry = DummyEntry("x" * (constants.MAX_TITLE_LENGTH + 2))
+    state.title_char_label = DummyLabel()
+
+    state.on_title_change()
+    assert len(state.title_entry.get()) == constants.MAX_TITLE_LENGTH
+    assert state.title_char_label.foreground == "red"
+
+
+def test_on_description_change__truncates_and_colors():
+    state = viewer_state.ViewerState(root=object())
+    state.desc_text = DummyText("x" * (constants.MAX_DESCRIPTION_LENGTH + 2))
+    state.desc_char_label = DummyLabel()
+
+    state.on_description_change()
+    assert len(state.desc_text.get()) == constants.MAX_DESCRIPTION_LENGTH
+    assert state.desc_char_label.foreground == "red"
+
+
+def test_focus_out_triggers_callback():
+    state = viewer_state.ViewerState(root=object())
+    called = []
+    state.update_button_states_callback = lambda: called.append(True)
+
+    state.on_title_focus_out()
+    state.on_description_focus_out()
+    state.on_keywords_focus_out()
+    assert len(called) == 3
+
+
+def test_keywords_change_and_refresh():
+    state = viewer_state.ViewerState(root=object())
+    state.keywords_tag_entry = DummyTagEntry(tags=["one", "two"])
+    state.on_keywords_change()
+    assert state.keywords_list == ["one", "two"]
+
+    state.keywords_list = ["three"]
+    state.refresh_keywords_display()
+    assert state.keywords_tag_entry.set_calls == [["three"]]
+
+
+def test_handle_title_input_moves_focus():
+    state = viewer_state.ViewerState(root=object())
+    state.desc_text = DummyText()
+    state.handle_title_input(None)
+    assert state.desc_text.focused is True
+
+
+def test_load_metadata_from_record_and_collect():
+    state = viewer_state.ViewerState(root=object())
+    state.title_entry = DummyEntry()
+    state.desc_text = DummyText()
+    state.title_char_label = DummyLabel()
+    state.desc_char_label = DummyLabel()
+    state.keywords_tag_entry = DummyTagEntry()
+    state.editorial_var = DummyVar()
+
+    record = {
+        constants.COL_TITLE: "Title",
+        constants.COL_DESCRIPTION: "Desc",
+        constants.COL_KEYWORDS: "one, two",
+        constants.COL_EDITORIAL: "yes",
+    }
+    state.load_metadata_from_record(record)
+
+    assert state.title_entry.get() == "Title"
+    assert state.desc_text.get() == "Desc"
+    assert state.keywords_list == ["one", "two"]
+    assert state.editorial_var.get() is True
+
+    collected = state.collect_metadata()
+    assert collected["title"] == "Title"
+    assert collected["editorial"] is True
+
+
+def test_collect_metadata__missing_widgets():
+    state = viewer_state.ViewerState(root=object())
+    assert state.collect_metadata() == {}

--- a/integratesortedphotos/tests/__init__.py
+++ b/integratesortedphotos/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for integratesortedphotos."""

--- a/integratesortedphotos/tests/integration/test_copy_files_pipeline__scenarios.py
+++ b/integratesortedphotos/tests/integration/test_copy_files_pipeline__scenarios.py
@@ -1,0 +1,25 @@
+"""
+Integration tests for integratesortedphotos copy pipeline.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "integratesortedphotos"
+sys.path.insert(0, str(package_root))
+
+from integratesortedphotoslib.copy_files import copy_files_with_preserved_dates
+
+
+def test_copy_files_with_preserved_dates_copies_tree(tmp_path):
+    src = tmp_path / "src"
+    dest = tmp_path / "dest"
+    (src / "nested").mkdir(parents=True)
+    file_path = src / "nested" / "photo.jpg"
+    file_path.write_bytes(b"data")
+
+    copy_files_with_preserved_dates(str(src), str(dest))
+
+    copied = dest / "nested" / "photo.jpg"
+    assert copied.exists()

--- a/integratesortedphotos/tests/performance/test_copy_files__bulk.py
+++ b/integratesortedphotos/tests/performance/test_copy_files__bulk.py
@@ -1,0 +1,24 @@
+"""
+Performance-oriented tests for copy_files_with_preserved_dates.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "integratesortedphotos"
+sys.path.insert(0, str(package_root))
+
+from integratesortedphotoslib.copy_files import copy_files_with_preserved_dates
+
+
+def test_copy_files_bulk(tmp_path):
+    src = tmp_path / "src"
+    dest = tmp_path / "dest"
+    src.mkdir()
+
+    for i in range(50):
+        (src / f"file_{i}.txt").write_text(f"data {i}", encoding="utf-8")
+
+    copy_files_with_preserved_dates(str(src), str(dest))
+    assert (dest / "file_49.txt").exists()

--- a/integratesortedphotos/tests/security/test_main__missing_source_guard.py
+++ b/integratesortedphotos/tests/security/test_main__missing_source_guard.py
@@ -1,0 +1,38 @@
+"""
+Security-focused tests for integrate_sorted_photos main guard rails.
+"""
+
+import types
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "integratesortedphotos"
+sys.path.insert(0, str(package_root))
+
+import integrate_sorted_photos
+
+
+def test_main_skips_copy_when_sorted_folder_missing(monkeypatch):
+    args = types.SimpleNamespace(
+        sortedFolder="X:/missing",
+        targetFolder="X:/dest",
+        log_dir="X:/logs",
+        debug=False,
+    )
+
+    called = {"copy": False}
+
+    monkeypatch.setattr(integrate_sorted_photos, "parse_arguments", lambda: args)
+    monkeypatch.setattr(integrate_sorted_photos, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(integrate_sorted_photos, "get_log_filename", lambda _p: "log.txt")
+    monkeypatch.setattr(integrate_sorted_photos, "setup_logging", lambda **_k: None)
+    monkeypatch.setattr(
+        integrate_sorted_photos,
+        "copy_files_with_preserved_dates",
+        lambda *_a, **_k: called.__setitem__("copy", True),
+    )
+    monkeypatch.setattr(integrate_sorted_photos.os.path, "exists", lambda _p: False)
+
+    integrate_sorted_photos.main()
+    assert called["copy"] is False

--- a/integratesortedphotos/tests/unit/__init__.py
+++ b/integratesortedphotos/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for integratesortedphotos."""

--- a/integratesortedphotos/tests/unit/test_copy_files__scenarios.py
+++ b/integratesortedphotos/tests/unit/test_copy_files__scenarios.py
@@ -1,0 +1,68 @@
+"""
+Unit tests for integratesortedphotoslib.copy_files.copy_files_with_preserved_dates.
+"""
+
+import os
+import sys
+import tempfile
+import shutil
+from pathlib import Path
+import pytest
+
+project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+from integratesortedphotoslib.copy_files import copy_files_with_preserved_dates
+
+
+class TestCopyFilesWithPreservedDates:
+    @pytest.fixture
+    def temp_dirs(self):
+        src = tempfile.mkdtemp(prefix="test_copy_src_")
+        dest = tempfile.mkdtemp(prefix="test_copy_dest_")
+        yield src, dest
+        shutil.rmtree(src, ignore_errors=True)
+        shutil.rmtree(dest, ignore_errors=True)
+
+    def test_copies_nested_files(self, temp_dirs):
+        src, dest = temp_dirs
+        nested = Path(src, "nested")
+        nested.mkdir(parents=True, exist_ok=True)
+        (Path(src) / "a.txt").write_text("a", encoding="utf-8")
+        (nested / "b.txt").write_text("b", encoding="utf-8")
+
+        copy_files_with_preserved_dates(src, dest)
+
+        assert Path(dest, "a.txt").exists()
+        assert Path(dest, "nested", "b.txt").exists()
+
+    def test_skips_existing_destination(self, temp_dirs):
+        src, dest = temp_dirs
+        src_file = Path(src, "a.txt")
+        dest_file = Path(dest, "a.txt")
+        src_file.write_text("src", encoding="utf-8")
+        dest_file.write_text("dest", encoding="utf-8")
+
+        copy_files_with_preserved_dates(src, dest)
+
+        assert dest_file.read_text(encoding="utf-8") == "dest"
+
+    def test_empty_source_noop(self, temp_dirs):
+        src, dest = temp_dirs
+        copy_files_with_preserved_dates(src, dest)
+        assert list(Path(dest).rglob("*")) == []
+
+    def test_copy_failure_raises(self, temp_dirs, monkeypatch):
+        src, dest = temp_dirs
+        src_file = Path(src, "a.txt")
+        src_file.write_text("src", encoding="utf-8")
+
+        from integratesortedphotoslib import copy_files as module
+
+        def _boom(*args, **kwargs):
+            raise PermissionError("nope")
+
+        monkeypatch.setattr(module, "copy_file", _boom)
+
+        with pytest.raises(PermissionError):
+            copy_files_with_preserved_dates(src, dest)

--- a/integratesortedphotos/tests/unit/test_integrate_sorted_photos__import.py
+++ b/integratesortedphotos/tests/unit/test_integrate_sorted_photos__import.py
@@ -1,0 +1,14 @@
+"""
+Import smoke test for integrate_sorted_photos.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "integratesortedphotos"
+sys.path.insert(0, str(package_root))
+
+
+def test_import_integrate_sorted_photos():
+    import integrate_sorted_photos  # noqa: F401

--- a/integratesortedphotos/tests/unit/test_integrate_sorted_photos__main__scenarios.py
+++ b/integratesortedphotos/tests/unit/test_integrate_sorted_photos__main__scenarios.py
@@ -1,0 +1,38 @@
+"""
+Unit tests for integratesortedphotos/integrate_sorted_photos.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "integratesortedphotos"
+sys.path.insert(0, str(package_root))
+
+import integrate_sorted_photos as main_module
+
+
+def test_main__missing_sorted_folder(monkeypatch):
+    args = SimpleNamespace(sortedFolder="C:/missing", targetFolder="C:/target", log_dir="C:/logs", debug=False)
+    monkeypatch.setattr(main_module, "parse_arguments", lambda: args)
+    monkeypatch.setattr(main_module, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(main_module, "setup_logging", lambda **_k: None)
+    monkeypatch.setattr(main_module.os.path, "exists", lambda _p: False)
+
+    assert main_module.main() is None
+
+
+def test_main__calls_copy(monkeypatch):
+    args = SimpleNamespace(sortedFolder="C:/sorted", targetFolder="C:/target", log_dir="C:/logs", debug=False)
+    monkeypatch.setattr(main_module, "parse_arguments", lambda: args)
+    monkeypatch.setattr(main_module, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(main_module, "setup_logging", lambda **_k: None)
+    monkeypatch.setattr(main_module.os.path, "exists", lambda _p: True)
+    called = []
+    monkeypatch.setattr(main_module, "copy_files_with_preserved_dates", lambda *_a: called.append(True))
+
+    main_module.main()
+    assert called

--- a/integratesortedphotos/tests/unit/test_integratesortedphotos_constants__sanity.py
+++ b/integratesortedphotos/tests/unit/test_integratesortedphotos_constants__sanity.py
@@ -1,0 +1,17 @@
+"""
+Unit tests for integratesortedphotoslib/constants.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "integratesortedphotos"
+sys.path.insert(0, str(package_root))
+
+from integratesortedphotoslib import constants
+
+
+def test_constants__types():
+    assert isinstance(constants.SOURCE_DIR, str)
+    assert isinstance(constants.DEST_DIR, str)

--- a/integratesortedphotos/tests/unit/test_shared_csv_sanitizer__scenarios.py
+++ b/integratesortedphotos/tests/unit/test_shared_csv_sanitizer__scenarios.py
@@ -1,0 +1,21 @@
+"""
+Unit tests for integratesortedphotos/shared/csv_sanitizer.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "integratesortedphotos"
+sys.path.insert(0, str(package_root))
+
+from shared.csv_sanitizer import sanitize_field, is_dangerous
+
+
+def test_sanitize_field__dangerous_prefix():
+    assert sanitize_field("=1+1") == "'=1+1"
+
+
+def test_is_dangerous__safe_and_unsafe():
+    assert is_dangerous("=1+1") is True
+    assert is_dangerous("safe") is False

--- a/integratesortedphotos/tests/unit/test_shared_file_operations__scenarios.py
+++ b/integratesortedphotos/tests/unit/test_shared_file_operations__scenarios.py
@@ -1,0 +1,22 @@
+"""
+Unit tests for integratesortedphotos/shared/file_operations.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "integratesortedphotos"
+sys.path.insert(0, str(package_root))
+
+import shared.file_operations as file_ops
+
+
+def test_copy_file__creates_dest_dir(tmp_path):
+    src = tmp_path / "src.txt"
+    src.write_text("x", encoding="utf-8")
+    dest = tmp_path / "out" / "dest.txt"
+
+    file_ops.copy_file(str(src), str(dest), overwrite=True)
+
+    assert dest.exists()

--- a/integratesortedphotos/tests/unit/test_shared_hash_utils__scenarios.py
+++ b/integratesortedphotos/tests/unit/test_shared_hash_utils__scenarios.py
@@ -1,0 +1,33 @@
+"""
+Unit tests for integratesortedphotos/shared/hash_utils.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "integratesortedphotos"
+sys.path.insert(0, str(package_root))
+
+import shared.hash_utils as hash_utils
+
+
+def test_compute_file_hash__md5(tmp_path):
+    file_path = tmp_path / "data.txt"
+    file_path.write_text("abc", encoding="utf-8")
+
+    result = hash_utils.compute_file_hash(str(file_path), method="md5")
+    assert len(result) == 32
+
+
+def test_compute_file_hash__xxhash_fallback(monkeypatch, tmp_path):
+    file_path = tmp_path / "data.txt"
+    file_path.write_text("abc", encoding="utf-8")
+
+    monkeypatch.setattr(hash_utils, "XXHASH_AVAILABLE", False)
+    hash_utils._xxhash_warning_logged = False
+
+    result = hash_utils.compute_file_hash(str(file_path), method="xxhash64")
+    assert len(result) == 32

--- a/integratesortedphotos/tests/unit/test_shared_logging_config__scenarios.py
+++ b/integratesortedphotos/tests/unit/test_shared_logging_config__scenarios.py
@@ -1,0 +1,88 @@
+"""
+Unit tests for integratesortedphotos/shared/logging_config.py.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "integratesortedphotos"
+sys.path.insert(0, str(package_root))
+
+import shared.logging_config as logging_config
+
+
+class DummyHandler:
+    def __init__(self, *_args, **_kwargs):
+        self.formatter = None
+
+    def setFormatter(self, formatter):
+        self.formatter = formatter
+
+
+class DummyLogger:
+    def __init__(self):
+        self.handlers = [DummyHandler()]
+        self.level = None
+
+    def setLevel(self, level):
+        self.level = level
+
+    def addHandler(self, handler):
+        self.handlers.append(handler)
+
+    def removeHandler(self, handler):
+        self.handlers.remove(handler)
+
+
+class DummyFormatter:
+    def __init__(self, *_args, **_kwargs):
+        return None
+
+
+def test_setup_logging__missing_config_raises(monkeypatch):
+    def fail_open(*_args, **_kwargs):
+        raise OSError("missing")
+
+    monkeypatch.setattr(logging_config, "open", fail_open)
+
+    with pytest.raises(Exception):
+        logging_config.setup_logging()
+
+
+def test_setup_logging__sets_level_and_handlers(monkeypatch):
+    dummy_logger = DummyLogger()
+
+    monkeypatch.setattr(logging_config.logging, "getLogger", lambda: dummy_logger)
+    monkeypatch.setattr(logging_config.logging, "StreamHandler", DummyHandler)
+    monkeypatch.setattr(logging_config.logging, "FileHandler", DummyHandler)
+    monkeypatch.setattr(logging_config.colorlog, "ColoredFormatter", DummyFormatter)
+
+    def fake_open(*_args, **_kwargs):
+        class DummyFile:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return '{"DEBUG": "white", "INFO": "green", "WARNING": "yellow", "ERROR": "red", "CRITICAL": "red"}'
+
+        return DummyFile()
+
+    monkeypatch.setattr(logging_config, "open", fake_open)
+    monkeypatch.setattr(logging_config.json, "load", lambda _f: {
+        "DEBUG": "white",
+        "INFO": "green",
+        "WARNING": "yellow",
+        "ERROR": "red",
+        "CRITICAL": "red",
+    })
+
+    logging_config.setup_logging(debug=False, log_file="C:/logs/test.log")
+
+    assert dummy_logger.level == logging_config.logging.INFO
+    assert len(dummy_logger.handlers) == 2

--- a/integratesortedphotos/tests/unit/test_shared_modules__scenarios.py
+++ b/integratesortedphotos/tests/unit/test_shared_modules__scenarios.py
@@ -1,0 +1,29 @@
+"""
+Unit tests for integratesortedphotos/shared modules.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "integratesortedphotos"
+sys.path.insert(0, str(package_root))
+
+from shared import utils as shared_utils
+
+
+def test_utils__get_log_filename(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["C:/tools/run_me.py"])
+
+    class DummyDateTime:
+        @classmethod
+        def now(cls):
+            class Dummy:
+                def strftime(self, _fmt):
+                    return "2020-01-01_12-00-00"
+
+            return Dummy()
+
+    monkeypatch.setattr(shared_utils, "datetime", DummyDateTime)
+    result = shared_utils.get_log_filename("C:/logs")
+    assert result.endswith("run_me_Log_2020-01-01_12-00-00.log")

--- a/integratesortedphotos/tests/unit/test_shared_utils__scenarios.py
+++ b/integratesortedphotos/tests/unit/test_shared_utils__scenarios.py
@@ -1,0 +1,36 @@
+"""
+Unit tests for integratesortedphotos/shared/utils.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "integratesortedphotos"
+sys.path.insert(0, str(package_root))
+
+import shared.utils as utils
+
+
+def test_get_script_name__uses_argv(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["C:/tools/run_me.py"])
+    assert utils.get_script_name() == "run_me"
+
+
+def test_get_log_filename__formats(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["C:/tools/run_me.py"])
+
+    class DummyDateTime:
+        @classmethod
+        def now(cls):
+            class Dummy:
+                def strftime(self, _fmt):
+                    return "2020-01-01_12-00-00"
+
+            return Dummy()
+
+    monkeypatch.setattr(utils, "datetime", DummyDateTime)
+    result = utils.get_log_filename("C:/logs")
+    assert result.endswith("run_me_Log_2020-01-01_12-00-00.log")

--- a/launchphotobanks/tests/__init__.py
+++ b/launchphotobanks/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for launchphotobanks."""

--- a/launchphotobanks/tests/integration/test_launch_photo_banks__dry_run.py
+++ b/launchphotobanks/tests/integration/test_launch_photo_banks__dry_run.py
@@ -1,0 +1,34 @@
+"""
+Integration tests for launch_photo_banks dry-run path.
+"""
+
+import types
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "launchphotobanks"
+sys.path.insert(0, str(package_root))
+
+import launch_photo_banks
+
+
+def test_main_dry_run_uses_csv(tmp_path, monkeypatch):
+    csv_path = tmp_path / "banks.csv"
+    csv_path.write_text("bank_name,url\nBankA,https://example.com\n", encoding="utf-8")
+
+    args = types.SimpleNamespace(
+        bank_csv=str(csv_path),
+        log_dir=str(tmp_path / "logs"),
+        debug=False,
+        delay=0,
+        banks=None,
+        dry_run=True,
+    )
+
+    monkeypatch.setattr(launch_photo_banks, "parse_arguments", lambda: args)
+    monkeypatch.setattr(launch_photo_banks, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(launch_photo_banks, "get_log_filename", lambda _p: "log.txt")
+    monkeypatch.setattr(launch_photo_banks, "setup_logging", lambda **_k: None)
+
+    assert launch_photo_banks.main() == 0

--- a/launchphotobanks/tests/performance/test_bank_launcher__bulk_load.py
+++ b/launchphotobanks/tests/performance/test_bank_launcher__bulk_load.py
@@ -1,0 +1,23 @@
+"""
+Performance-oriented tests for bank launcher CSV loading.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "launchphotobanks"
+sys.path.insert(0, str(package_root))
+
+from launchphotobankslib.bank_launcher import BankLauncher
+
+
+def test_load_many_banks(tmp_path):
+    csv_path = tmp_path / "banks.csv"
+    rows = ["bank_name,url"]
+    for i in range(200):
+        rows.append(f"Bank{i},https://example.com/{i}")
+    csv_path.write_text("\n".join(rows), encoding="utf-8")
+
+    launcher = BankLauncher(str(csv_path))
+    assert len(launcher.get_all_bank_names()) == 200

--- a/launchphotobanks/tests/security/test_bank_launcher__rejects_javascript_urls.py
+++ b/launchphotobanks/tests/security/test_bank_launcher__rejects_javascript_urls.py
@@ -1,0 +1,24 @@
+"""
+Security-focused tests for URL validation in bank launcher.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "launchphotobanks"
+sys.path.insert(0, str(package_root))
+
+from launchphotobankslib.bank_launcher import BankLauncher
+
+
+def test_rejects_javascript_urls(tmp_path):
+    csv_path = tmp_path / "banks.csv"
+    csv_path.write_text(
+        "bank_name,url\nBad,javascript:alert(1)\nGood,https://example.com\n",
+        encoding="utf-8",
+    )
+
+    launcher = BankLauncher(str(csv_path))
+    banks = launcher.get_all_bank_names()
+    assert banks == ["Good"]

--- a/launchphotobanks/tests/unit/__init__.py
+++ b/launchphotobanks/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for launchphotobanks."""

--- a/launchphotobanks/tests/unit/test_bank_launcher__scenarios.py
+++ b/launchphotobanks/tests/unit/test_bank_launcher__scenarios.py
@@ -1,0 +1,80 @@
+"""
+Unit tests for launchphotobankslib/bank_launcher.py.
+"""
+
+import csv
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "launchphotobanks"
+sys.path.insert(0, str(package_root))
+
+from launchphotobankslib.bank_launcher import BankLauncher
+from launchphotobankslib import constants as lp_constants
+
+
+def write_csv(path, rows, fieldnames):
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def test_load_banks__valid_csv(tmp_path):
+    csv_path = tmp_path / "banks.csv"
+    write_csv(
+        csv_path,
+        [{"BankName": "TestBank", "URL": "https://example.com"}],
+        ["BankName", "URL"],
+    )
+
+    launcher = BankLauncher(str(csv_path))
+
+    assert launcher.get_all_bank_names() == ["TestBank"]
+    assert launcher.get_bank_url("TestBank") == "https://example.com"
+
+
+def test_load_banks__missing_header_raises(tmp_path):
+    csv_path = tmp_path / "banks.csv"
+    write_csv(csv_path, [{"Name": "A", "Link": "https://x"}], ["Name", "Link"])
+
+    with pytest.raises(ValueError):
+        BankLauncher(str(csv_path))
+
+
+def test_load_banks__invalid_url_skipped(tmp_path):
+    csv_path = tmp_path / "banks.csv"
+    write_csv(
+        csv_path,
+        [{"BankName": "Bad", "URL": "notaurl"}],
+        ["BankName", "URL"],
+    )
+
+    with pytest.raises(ValueError):
+        BankLauncher(str(csv_path))
+
+
+def test_is_valid_url():
+    launcher = BankLauncher.__new__(BankLauncher)
+    assert launcher._is_valid_url("https://example.com") is True
+    assert launcher._is_valid_url("notaurl") is False
+
+
+def test_launch_banks__unknown_bank_returns_false(tmp_path, monkeypatch):
+    csv_path = tmp_path / "banks.csv"
+    write_csv(
+        csv_path,
+        [{"BankName": "Known", "URL": "https://example.com"}],
+        ["BankName", "URL"],
+    )
+
+    launcher = BankLauncher(str(csv_path))
+    monkeypatch.setattr("webbrowser.open_new_tab", lambda _u: True)
+
+    results = launcher.launch_banks(["Unknown"], delay=0)
+
+    assert results["Unknown"] is False

--- a/launchphotobanks/tests/unit/test_file_operations__copy_move_file__scenarios.py
+++ b/launchphotobanks/tests/unit/test_file_operations__copy_move_file__scenarios.py
@@ -1,0 +1,79 @@
+"""
+Unit tests for copy_file, move_file, ensure_directory in launchphotobanks/shared/file_operations.py.
+"""
+
+import os
+import sys
+import tempfile
+import shutil
+from pathlib import Path
+import pytest
+
+project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+from shared.file_operations import copy_file, move_file, ensure_directory
+
+
+class TestFileOperations:
+    @pytest.fixture
+    def temp_dirs(self):
+        src = tempfile.mkdtemp(prefix="test_file_src_")
+        dest = tempfile.mkdtemp(prefix="test_file_dest_")
+        yield src, dest
+        shutil.rmtree(src, ignore_errors=True)
+        shutil.rmtree(dest, ignore_errors=True)
+
+    def test_copy_file_creates_dest_dir(self, temp_dirs):
+        src, dest = temp_dirs
+        src_file = Path(src, "a.txt")
+        src_file.write_text("abc", encoding="utf-8")
+
+        dest_file = Path(dest, "nested", "a.txt")
+        copy_file(str(src_file), str(dest_file))
+
+        assert dest_file.exists()
+        assert dest_file.read_text(encoding="utf-8") == "abc"
+
+    def test_copy_file_overwrite_false_skips(self, temp_dirs):
+        src, dest = temp_dirs
+        src_file = Path(src, "a.txt")
+        dest_file = Path(dest, "a.txt")
+        src_file.write_text("src", encoding="utf-8")
+        dest_file.write_text("dest", encoding="utf-8")
+
+        copy_file(str(src_file), str(dest_file), overwrite=False)
+        assert dest_file.read_text(encoding="utf-8") == "dest"
+
+    def test_copy_file_missing_source_raises(self, temp_dirs):
+        src, dest = temp_dirs
+        with pytest.raises(Exception):
+            copy_file(str(Path(src, "missing.txt")), str(Path(dest, "missing.txt")))
+
+    def test_move_file_creates_dest_dir(self, temp_dirs):
+        src, dest = temp_dirs
+        src_file = Path(src, "a.txt")
+        src_file.write_text("abc", encoding="utf-8")
+
+        dest_file = Path(dest, "nested", "a.txt")
+        move_file(str(src_file), str(dest_file))
+
+        assert dest_file.exists()
+        assert not src_file.exists()
+
+    def test_move_file_overwrite_false_skips(self, temp_dirs):
+        src, dest = temp_dirs
+        src_file = Path(src, "a.txt")
+        dest_file = Path(dest, "a.txt")
+        src_file.write_text("src", encoding="utf-8")
+        dest_file.write_text("dest", encoding="utf-8")
+
+        move_file(str(src_file), str(dest_file), overwrite=False)
+        assert src_file.exists()
+        assert dest_file.read_text(encoding="utf-8") == "dest"
+
+    def test_ensure_directory(self, temp_dirs):
+        _, dest = temp_dirs
+        target = Path(dest, "deep", "nested")
+        ensure_directory(str(target))
+        assert target.exists()

--- a/launchphotobanks/tests/unit/test_file_operations__copy_move_folder__scenarios.py
+++ b/launchphotobanks/tests/unit/test_file_operations__copy_move_folder__scenarios.py
@@ -1,0 +1,103 @@
+"""
+Unit tests for copy_folder, move_folder, delete_folder in launchphotobanks/shared/file_operations.py.
+"""
+
+import os
+import sys
+import tempfile
+import shutil
+from pathlib import Path
+import re
+import pytest
+
+project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+from shared.file_operations import copy_folder, move_folder, delete_folder
+
+
+class TestFolderOperations:
+    @pytest.fixture
+    def folders(self):
+        src = tempfile.mkdtemp(prefix="test_src_")
+        dest = tempfile.mkdtemp(prefix="test_dest_")
+        yield src, dest
+        shutil.rmtree(src, ignore_errors=True)
+        shutil.rmtree(dest, ignore_errors=True)
+
+    def _make_tree(self, root: str):
+        nested = os.path.join(root, "nested")
+        os.makedirs(nested, exist_ok=True)
+        Path(root, "a.txt").write_text("a", encoding="utf-8")
+        Path(nested, "b.txt").write_text("b", encoding="utf-8")
+
+    def test_copy_folder_basic(self, folders):
+        src, dest = folders
+        self._make_tree(src)
+
+        copy_folder(src, dest, overwrite=True)
+
+        assert os.path.exists(os.path.join(dest, "a.txt"))
+        assert os.path.exists(os.path.join(dest, "nested", "b.txt"))
+
+    def test_copy_folder_overwrite_false_noop(self, folders):
+        src, dest = folders
+        self._make_tree(src)
+        Path(dest, "existing.txt").write_text("x", encoding="utf-8")
+
+        copy_folder(src, dest, overwrite=False)
+
+        assert not os.path.exists(os.path.join(dest, "a.txt"))
+        assert os.path.exists(os.path.join(dest, "existing.txt"))
+
+    def test_copy_folder_pattern_filter(self, folders):
+        src, dest = folders
+        self._make_tree(src)
+        Path(src, "keep.log").write_text("k", encoding="utf-8")
+
+        copy_folder(src, dest, pattern=r"\.log$")
+
+        assert os.path.exists(os.path.join(dest, "keep.log"))
+        assert not os.path.exists(os.path.join(dest, "a.txt"))
+
+    def test_copy_folder_invalid_regex(self, folders):
+        src, dest = folders
+        self._make_tree(src)
+        with pytest.raises(re.error):
+            copy_folder(src, dest, pattern="[")
+
+    def test_move_folder_basic(self, folders):
+        src, dest = folders
+        self._make_tree(src)
+
+        move_folder(src, dest, overwrite=True)
+
+        assert not os.path.exists(src)
+        assert os.path.exists(os.path.join(dest, "a.txt"))
+        assert os.path.exists(os.path.join(dest, "nested", "b.txt"))
+
+    def test_move_folder_overwrite_false_skips(self, folders):
+        src, dest = folders
+        self._make_tree(src)
+        Path(dest, "existing.txt").write_text("x", encoding="utf-8")
+
+        move_folder(src, dest, overwrite=False)
+
+        assert os.path.exists(src)
+        assert os.path.exists(os.path.join(src, "a.txt"))
+        assert os.path.exists(os.path.join(dest, "existing.txt"))
+
+    def test_move_folder_empty_source_noop(self, folders):
+        src, dest = folders
+        move_folder(src, dest, overwrite=True)
+        assert os.path.exists(src)
+
+    def test_delete_folder(self, folders):
+        src, _ = folders
+        self._make_tree(src)
+        delete_folder(src)
+        assert not os.path.exists(src)
+
+    def test_delete_folder_missing_raises(self):
+        with pytest.raises(Exception):
+            delete_folder("Z:/this/should/not/exist")

--- a/launchphotobanks/tests/unit/test_file_operations__csv_io__scenarios.py
+++ b/launchphotobanks/tests/unit/test_file_operations__csv_io__scenarios.py
@@ -1,0 +1,77 @@
+"""
+Unit tests for load_csv and save_csv in launchphotobanks/shared/file_operations.py.
+"""
+
+import os
+import sys
+import tempfile
+import shutil
+from pathlib import Path
+import builtins
+import pytest
+
+project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+from shared.file_operations import load_csv, save_csv
+
+
+class TestCsvIO:
+    @pytest.fixture
+    def temp_dir(self):
+        root = tempfile.mkdtemp(prefix="test_csv_io_")
+        yield root
+        shutil.rmtree(root, ignore_errors=True)
+
+    def test_load_csv_basic(self, temp_dir):
+        csv_path = Path(temp_dir, "data.csv")
+        csv_path.write_text("a,b\n1,2\n3,4\n", encoding="utf-8-sig")
+
+        records = load_csv(str(csv_path))
+        assert records == [{"a": "1", "b": "2"}, {"a": "3", "b": "4"}]
+
+    def test_load_csv_custom_delimiter(self, temp_dir):
+        csv_path = Path(temp_dir, "data.csv")
+        csv_path.write_text("a;b\n1;2\n", encoding="utf-8-sig")
+
+        records = load_csv(str(csv_path), delimiter=";")
+        assert records == [{"a": "1", "b": "2"}]
+
+    def test_load_csv_header_only(self, temp_dir):
+        csv_path = Path(temp_dir, "data.csv")
+        csv_path.write_text("a,b\n", encoding="utf-8-sig")
+
+        records = load_csv(str(csv_path))
+        assert records == []
+
+    def test_load_csv_invalid_encoding(self, temp_dir):
+        csv_path = Path(temp_dir, "data.csv")
+        csv_path.write_text("a,b\n1,2\n", encoding="utf-8-sig")
+
+        with pytest.raises(Exception):
+            load_csv(str(csv_path), encoding="invalid-encoding")
+
+    def test_save_csv_basic(self, temp_dir):
+        csv_path = Path(temp_dir, "out.csv")
+        records = [{"a": "1", "b": "2"}]
+
+        save_csv(records, str(csv_path))
+        assert csv_path.exists()
+        content = csv_path.read_text(encoding="utf-8-sig")
+        assert "a,b" in content
+
+    def test_save_csv_empty_records_no_file(self, temp_dir):
+        csv_path = Path(temp_dir, "out.csv")
+        save_csv([], str(csv_path))
+        assert not csv_path.exists()
+
+    def test_save_csv_open_error(self, temp_dir, monkeypatch):
+        csv_path = Path(temp_dir, "out.csv")
+        records = [{"a": "1", "b": "2"}]
+
+        def _raise(*args, **kwargs):
+            raise PermissionError("nope")
+
+        monkeypatch.setattr(builtins, "open", _raise)
+        with pytest.raises(PermissionError):
+            save_csv(records, str(csv_path))

--- a/launchphotobanks/tests/unit/test_file_operations__dedupe_hash__scenarios.py
+++ b/launchphotobanks/tests/unit/test_file_operations__dedupe_hash__scenarios.py
@@ -1,0 +1,69 @@
+"""
+Unit tests for unify_duplicate_files and get_hash_map_from_folder in launchphotobanks/shared/file_operations.py.
+"""
+
+import os
+import sys
+import tempfile
+import shutil
+from pathlib import Path
+import pytest
+
+project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+from shared import file_operations
+
+
+class TestDedupeAndHash:
+    @pytest.fixture
+    def temp_dir(self):
+        root = tempfile.mkdtemp(prefix="test_dedupe_")
+        yield root
+        shutil.rmtree(root, ignore_errors=True)
+
+    def test_get_hash_map_empty(self, temp_dir):
+        result = file_operations.get_hash_map_from_folder(temp_dir, pattern="PICT")
+        assert result == {}
+
+    def test_get_hash_map_pattern_filter(self, temp_dir, monkeypatch):
+        Path(temp_dir, "PICT_1.txt").write_text("a", encoding="utf-8")
+        Path(temp_dir, "OTHER.txt").write_text("b", encoding="utf-8")
+
+        monkeypatch.setattr(file_operations, "compute_file_hash", lambda p: "hash")
+        result = file_operations.get_hash_map_from_folder(temp_dir, pattern="PICT")
+        assert len(result) == 1
+        only_path = next(iter(result.keys()))
+        assert os.path.basename(only_path) == "PICT_1.txt"
+
+    def test_get_hash_map_hash_error_skips(self, temp_dir, monkeypatch):
+        good = Path(temp_dir, "PICT_ok.txt")
+        bad = Path(temp_dir, "PICT_bad.txt")
+        good.write_text("a", encoding="utf-8")
+        bad.write_text("b", encoding="utf-8")
+
+        def fake_hash(path):
+            if path.endswith("PICT_bad.txt"):
+                raise RuntimeError("boom")
+            return "hash"
+
+        monkeypatch.setattr(file_operations, "compute_file_hash", fake_hash)
+        result = file_operations.get_hash_map_from_folder(temp_dir, pattern="PICT")
+        assert os.path.basename(next(iter(result.keys()))) == "PICT_ok.txt"
+
+    def test_unify_duplicate_files_no_duplicates(self, temp_dir, monkeypatch):
+        Path(temp_dir, "a.txt").write_text("a", encoding="utf-8")
+        Path(temp_dir, "bbbb.txt").write_text("b", encoding="utf-8")
+        monkeypatch.setattr(file_operations, "compute_file_hash", lambda p: os.path.basename(p))
+
+        file_operations.unify_duplicate_files(temp_dir, recursive=False)
+        assert set(os.listdir(temp_dir)) == {"a.txt", "bbbb.txt"}
+
+    def test_unify_duplicate_files_renames_to_shortest(self, temp_dir, monkeypatch):
+        Path(temp_dir, "aa.txt").write_text("same", encoding="utf-8")
+        Path(temp_dir, "bbbb.txt").write_text("same", encoding="utf-8")
+        monkeypatch.setattr(file_operations, "compute_file_hash", lambda p: "samehash")
+
+        file_operations.unify_duplicate_files(temp_dir, recursive=False)
+        names = os.listdir(temp_dir)
+        assert names == ["aa.txt"]

--- a/launchphotobanks/tests/unit/test_file_operations__list_files__scenarios.py
+++ b/launchphotobanks/tests/unit/test_file_operations__list_files__scenarios.py
@@ -1,0 +1,59 @@
+"""
+Unit tests for list_files in launchphotobanks/shared/file_operations.py.
+"""
+
+import os
+import sys
+import tempfile
+import shutil
+from pathlib import Path
+import re
+import pytest
+
+project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+from shared.file_operations import list_files
+
+
+class TestListFiles:
+    @pytest.fixture
+    def temp_dir(self):
+        root = tempfile.mkdtemp(prefix="test_list_files_")
+        nested = os.path.join(root, "nested")
+        os.makedirs(nested, exist_ok=True)
+        # Create files
+        Path(root, "a.txt").write_text("a", encoding="utf-8")
+        Path(root, "b.log").write_text("b", encoding="utf-8")
+        Path(nested, "c.txt").write_text("c", encoding="utf-8")
+        yield root
+        shutil.rmtree(root, ignore_errors=True)
+
+    def test_list_files_recursive(self, temp_dir):
+        files = list_files(temp_dir, recursive=True)
+        basenames = {os.path.basename(p) for p in files}
+        assert basenames == {"a.txt", "b.log", "c.txt"}
+
+    def test_list_files_non_recursive(self, temp_dir):
+        files = list_files(temp_dir, recursive=False)
+        basenames = {os.path.basename(p) for p in files}
+        assert basenames == {"a.txt", "b.log"}
+
+    def test_list_files_pattern_empty(self, temp_dir):
+        files = list_files(temp_dir, pattern="")
+        basenames = {os.path.basename(p) for p in files}
+        assert basenames == {"a.txt", "b.log", "c.txt"}
+
+    def test_list_files_pattern_regex(self, temp_dir):
+        files = list_files(temp_dir, pattern=r"\.txt$")
+        basenames = {os.path.basename(p) for p in files}
+        assert basenames == {"a.txt", "c.txt"}
+
+    def test_list_files_nonexistent_nonrecursive(self, temp_dir):
+        missing = os.path.join(temp_dir, "does_not_exist")
+        files = list_files(missing, recursive=False)
+        assert files == []
+
+    def test_list_files_invalid_regex(self, temp_dir):
+        with pytest.raises(re.error):
+            list_files(temp_dir, pattern="[")

--- a/launchphotobanks/tests/unit/test_launch_photo_banks__main__scenarios.py
+++ b/launchphotobanks/tests/unit/test_launch_photo_banks__main__scenarios.py
@@ -1,0 +1,82 @@
+"""
+Unit tests for launch_photo_banks.py.
+"""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "launchphotobanks"
+sys.path.insert(0, str(package_root))
+
+import launch_photo_banks as launch_module
+from launchphotobankslib import constants as lp_constants
+
+
+def make_args(tmp_path, **overrides):
+    defaults = dict(
+        bank_csv=str(tmp_path / "banks.csv"),
+        log_dir=str(tmp_path / "logs"),
+        debug=False,
+        delay=lp_constants.DEFAULT_DELAY_BETWEEN_OPENS,
+        banks=None,
+        dry_run=False,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def test_parse_arguments__defaults(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["launch_photo_banks.py"])
+    args = launch_module.parse_arguments()
+
+    assert args.bank_csv == lp_constants.DEFAULT_BANK_CSV
+    assert args.log_dir == lp_constants.DEFAULT_LOG_DIR
+    assert args.delay == lp_constants.DEFAULT_DELAY_BETWEEN_OPENS
+
+
+def test_main__invalid_banks_returns_error(monkeypatch, tmp_path):
+    args = make_args(tmp_path, banks=["Unknown"])
+    monkeypatch.setattr(launch_module, "parse_arguments", lambda: args)
+    monkeypatch.setattr(launch_module, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(launch_module, "get_log_filename", lambda _p: "log.txt")
+    monkeypatch.setattr(launch_module, "setup_logging", lambda **_k: None)
+
+    class DummyLauncher:
+        def __init__(self, _path):
+            pass
+
+        def get_all_bank_names(self):
+            return ["Known"]
+
+        def get_bank_url(self, bank):
+            return f"http://{bank}.test"
+
+    monkeypatch.setattr(launch_module, "BankLauncher", DummyLauncher)
+
+    assert launch_module.main() == 1
+
+
+def test_main__dry_run(monkeypatch, tmp_path):
+    args = make_args(tmp_path, banks=["BankA"], dry_run=True)
+    monkeypatch.setattr(launch_module, "parse_arguments", lambda: args)
+    monkeypatch.setattr(launch_module, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(launch_module, "get_log_filename", lambda _p: "log.txt")
+    monkeypatch.setattr(launch_module, "setup_logging", lambda **_k: None)
+
+    class DummyLauncher:
+        def __init__(self, _path):
+            pass
+
+        def get_all_bank_names(self):
+            return ["BankA"]
+
+        def get_bank_url(self, bank):
+            return f"http://{bank}.test"
+
+    monkeypatch.setattr(launch_module, "BankLauncher", DummyLauncher)
+
+    assert launch_module.main() == 0

--- a/launchphotobanks/tests/unit/test_launchphotobanks_constants__sanity.py
+++ b/launchphotobanks/tests/unit/test_launchphotobanks_constants__sanity.py
@@ -1,0 +1,19 @@
+"""
+Unit tests for launchphotobankslib/constants.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "launchphotobanks"
+sys.path.insert(0, str(package_root))
+
+from launchphotobankslib import constants
+
+
+def test_constants__types():
+    assert isinstance(constants.DEFAULT_BANK_CSV, str)
+    assert isinstance(constants.DEFAULT_LOG_DIR, str)
+    assert isinstance(constants.COLUMN_BANK_NAME, str)
+    assert isinstance(constants.COLUMN_URL, str)

--- a/launchphotobanks/tests/unit/test_shared_hash_utils__scenarios.py
+++ b/launchphotobanks/tests/unit/test_shared_hash_utils__scenarios.py
@@ -1,0 +1,21 @@
+"""
+Unit tests for launchphotobanks/shared/hash_utils.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "launchphotobanks"
+sys.path.insert(0, str(package_root))
+
+import shared.hash_utils as hash_utils
+
+
+def test_compute_file_hash__md5(tmp_path):
+    data_file = tmp_path / "data.bin"
+    data_file.write_bytes(b"abc")
+
+    result = hash_utils.compute_file_hash(str(data_file), method="md5")
+
+    assert len(result) == 32

--- a/launchphotobanks/tests/unit/test_shared_logging_config__scenarios.py
+++ b/launchphotobanks/tests/unit/test_shared_logging_config__scenarios.py
@@ -1,0 +1,88 @@
+"""
+Unit tests for launchphotobanks/shared/logging_config.py.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "launchphotobanks"
+sys.path.insert(0, str(package_root))
+
+import shared.logging_config as logging_config
+
+
+class DummyHandler:
+    def __init__(self, *_args, **_kwargs):
+        self.formatter = None
+
+    def setFormatter(self, formatter):
+        self.formatter = formatter
+
+
+class DummyLogger:
+    def __init__(self):
+        self.handlers = [DummyHandler()]
+        self.level = None
+
+    def setLevel(self, level):
+        self.level = level
+
+    def addHandler(self, handler):
+        self.handlers.append(handler)
+
+    def removeHandler(self, handler):
+        self.handlers.remove(handler)
+
+
+class DummyFormatter:
+    def __init__(self, *_args, **_kwargs):
+        return None
+
+
+def test_setup_logging__missing_config_raises(monkeypatch):
+    def fail_open(*_args, **_kwargs):
+        raise OSError("missing")
+
+    monkeypatch.setattr(logging_config, "open", fail_open)
+
+    with pytest.raises(Exception):
+        logging_config.setup_logging()
+
+
+def test_setup_logging__sets_level_and_handlers(monkeypatch):
+    dummy_logger = DummyLogger()
+
+    monkeypatch.setattr(logging_config.logging, "getLogger", lambda: dummy_logger)
+    monkeypatch.setattr(logging_config.logging, "StreamHandler", DummyHandler)
+    monkeypatch.setattr(logging_config.logging, "FileHandler", DummyHandler)
+    monkeypatch.setattr(logging_config.colorlog, "ColoredFormatter", DummyFormatter)
+
+    def fake_open(*_args, **_kwargs):
+        class DummyFile:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return '{"DEBUG": "white", "INFO": "green", "WARNING": "yellow", "ERROR": "red", "CRITICAL": "red"}'
+
+        return DummyFile()
+
+    monkeypatch.setattr(logging_config, "open", fake_open)
+    monkeypatch.setattr(logging_config.json, "load", lambda _f: {
+        "DEBUG": "white",
+        "INFO": "green",
+        "WARNING": "yellow",
+        "ERROR": "red",
+        "CRITICAL": "red",
+    })
+
+    logging_config.setup_logging(debug=False, log_file="C:/logs/test.log")
+
+    assert dummy_logger.level == logging_config.logging.INFO
+    assert len(dummy_logger.handlers) == 2

--- a/launchphotobanks/tests/unit/test_shared_utils__scenarios.py
+++ b/launchphotobanks/tests/unit/test_shared_utils__scenarios.py
@@ -1,0 +1,29 @@
+"""
+Unit tests for launchphotobanks/shared/utils.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "launchphotobanks"
+sys.path.insert(0, str(package_root))
+
+import shared.utils as utils
+
+
+def test_get_log_filename__format(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["C:/tools/run_me.py"])
+
+    class DummyDateTime:
+        @classmethod
+        def now(cls):
+            class Dummy:
+                def strftime(self, _fmt):
+                    return "2020-01-01_12-00-00"
+
+            return Dummy()
+
+    monkeypatch.setattr(utils, "datetime", DummyDateTime)
+    result = utils.get_log_filename("C:/logs")
+    assert result.endswith("run_me_Log_2020-01-01_12-00-00.log")

--- a/markmediaaschecked/tests/integration/test_markmediaaschecked__pipeline.py
+++ b/markmediaaschecked/tests/integration/test_markmediaaschecked__pipeline.py
@@ -1,0 +1,55 @@
+"""
+Integration tests for markmediaaschecked end-to-end flow.
+"""
+
+import csv
+import types
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "markmediaaschecked"
+sys.path.insert(0, str(package_root))
+
+import markmediaaschecked
+from markmediaascheckedlib.constants import STATUS_READY, STATUS_CHECKED
+
+
+def _write_csv(path: Path, records):
+    with open(path, "w", encoding="utf-8-sig", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(records[0].keys()))
+        writer.writeheader()
+        writer.writerows(records)
+
+
+def test_main_updates_status_and_creates_backup(tmp_path, monkeypatch):
+    csv_path = tmp_path / "photos.csv"
+    records = [
+        {"status_main": STATUS_READY, "Soubor": "img1.jpg", "Cesta": "x"},
+        {"status_main": "other", "Soubor": "img2.jpg", "Cesta": "x"},
+    ]
+    _write_csv(csv_path, records)
+
+    args = types.SimpleNamespace(
+        photo_csv_file=str(csv_path),
+        overwrite=True,
+        debug=False,
+        log_dir=str(tmp_path / "logs"),
+        include_edited=False,
+    )
+
+    monkeypatch.setattr(markmediaaschecked, "parse_arguments", lambda: args)
+    monkeypatch.setattr(markmediaaschecked, "setup_logging", lambda **_k: None)
+    monkeypatch.setattr(markmediaaschecked, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(markmediaaschecked, "get_log_filename", lambda _p: "log.txt")
+
+    markmediaaschecked.main()
+
+    backup_files = list(tmp_path.glob("photos.csv.*.old"))
+    assert backup_files
+
+    with open(csv_path, "r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.DictReader(handle)
+        rows = list(reader)
+
+    assert rows[0]["status_main"] == STATUS_CHECKED

--- a/markmediaaschecked/tests/performance/test_mark_handler__bulk.py
+++ b/markmediaaschecked/tests/performance/test_mark_handler__bulk.py
@@ -1,0 +1,20 @@
+"""
+Performance-oriented tests for mark handler updates.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "markmediaaschecked"
+sys.path.insert(0, str(package_root))
+
+from markmediaascheckedlib.constants import STATUS_READY, STATUS_CHECKED
+from markmediaascheckedlib.mark_handler import update_statuses
+
+
+def test_update_statuses_bulk():
+    records = [{"status_main": STATUS_READY} for _ in range(500)]
+    count = update_statuses(records, ["status_main"])
+    assert count == 500
+    assert records[0]["status_main"] == STATUS_CHECKED

--- a/markmediaaschecked/tests/security/test_save_csv__sanitizes_injection.py
+++ b/markmediaaschecked/tests/security/test_save_csv__sanitizes_injection.py
@@ -1,0 +1,26 @@
+"""
+Security-focused tests for CSV injection sanitization in save_csv.
+"""
+
+import csv
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "markmediaaschecked"
+sys.path.insert(0, str(package_root))
+
+from shared.file_operations import save_csv
+
+
+def test_save_csv_sanitizes_formula_injection(tmp_path):
+    records = [{"status_main": "=HYPERLINK(\"http://bad\")"}]
+    csv_path = tmp_path / "out.csv"
+
+    save_csv(records, str(csv_path))
+
+    with open(csv_path, "r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.DictReader(handle)
+        rows = list(reader)
+
+    assert rows[0]["status_main"].startswith("'=")

--- a/markmediaaschecked/tests/unit/__init__.py
+++ b/markmediaaschecked/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests package for markmediaaschecked."""

--- a/markmediaaschecked/tests/unit/test_mark_files__scenarios.py
+++ b/markmediaaschecked/tests/unit/test_mark_files__scenarios.py
@@ -1,0 +1,19 @@
+"""
+Unit tests for markmediaascheckedlib/mark_files.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "markmediaaschecked"
+sys.path.insert(0, str(package_root))
+
+from markmediaascheckedlib import constants
+from markmediaascheckedlib.mark_files import mark_files_as_checked
+
+
+def test_mark_files_as_checked__replaces_status():
+    data = [{"Status": constants.STATUS_READY}]
+    result = mark_files_as_checked(data)
+    assert result[0]["Status"] == constants.STATUS_CHECKED

--- a/markmediaaschecked/tests/unit/test_mark_handler__scenarios.py
+++ b/markmediaaschecked/tests/unit/test_mark_handler__scenarios.py
@@ -1,0 +1,55 @@
+"""
+Unit tests for markmediaascheckedlib/mark_handler.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "markmediaaschecked"
+sys.path.insert(0, str(package_root))
+
+from markmediaascheckedlib import constants
+from markmediaascheckedlib.mark_handler import (
+    extract_status_columns,
+    filter_ready_records,
+    update_statuses,
+    is_edited_photo,
+    filter_records_by_edit_type,
+)
+
+
+def test_extract_status_columns__case_insensitive():
+    records = [{"Shutterstock Status": "x", "Other": "y"}]
+    cols = extract_status_columns(records)
+    assert "Shutterstock Status" in cols
+
+
+def test_filter_ready_records__selects_ready():
+    records = [
+        {"Status A": constants.STATUS_READY},
+        {"Status A": "other"},
+    ]
+    ready = filter_ready_records(records, ["Status A"])
+    assert ready == [records[0]]
+
+
+def test_update_statuses__replaces_ready():
+    records = [{"Status A": constants.STATUS_READY}]
+    count = update_statuses(records, ["Status A"])
+    assert count == 1
+    assert records[0]["Status A"] == constants.STATUS_CHECKED
+
+
+def test_is_edited_photo__detects_tag():
+    record = {constants.COL_FILE: "photo_bw.jpg"}
+    assert is_edited_photo(record) is True
+
+
+def test_filter_records_by_edit_type__excludes_edited():
+    records = [
+        {constants.COL_FILE: "photo_bw.jpg"},
+        {constants.COL_FILE: "photo.jpg"},
+    ]
+    filtered = filter_records_by_edit_type(records, include_edited=False)
+    assert filtered == [records[1]]

--- a/markmediaaschecked/tests/unit/test_markmediaaschecked__main__scenarios.py
+++ b/markmediaaschecked/tests/unit/test_markmediaaschecked__main__scenarios.py
@@ -1,0 +1,66 @@
+"""
+Unit tests for markmediaaschecked.py.
+"""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "markmediaaschecked"
+sys.path.insert(0, str(package_root))
+
+import markmediaaschecked as mmc
+from markmediaascheckedlib import constants
+
+
+def make_args(tmp_path, **overrides):
+    defaults = dict(
+        photo_csv_file=str(tmp_path / "input.csv"),
+        overwrite=False,
+        debug=False,
+        log_dir=str(tmp_path / "logs"),
+        include_edited=False,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def test_parse_arguments__defaults(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["markmediaaschecked.py"])
+    args = mmc.parse_arguments()
+    assert args.photo_csv_file == constants.DEFAULT_PHOTO_CSV_FILE
+
+
+def test_main__no_records_returns(monkeypatch, tmp_path):
+    args = make_args(tmp_path)
+    monkeypatch.setattr(mmc, "parse_arguments", lambda: args)
+    monkeypatch.setattr(mmc, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(mmc, "get_log_filename", lambda _p: "log.txt")
+    monkeypatch.setattr(mmc, "setup_logging", lambda **_k: None)
+    monkeypatch.setattr(mmc, "load_csv", lambda _p: [])
+
+    assert mmc.main() is None
+
+
+def test_main__updates_and_saves(monkeypatch, tmp_path):
+    args = make_args(tmp_path)
+    monkeypatch.setattr(mmc, "parse_arguments", lambda: args)
+    monkeypatch.setattr(mmc, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(mmc, "get_log_filename", lambda _p: "log.txt")
+    monkeypatch.setattr(mmc, "setup_logging", lambda **_k: None)
+
+    records = [{"Status A": constants.STATUS_READY}]
+    monkeypatch.setattr(mmc, "load_csv", lambda _p: records)
+    monkeypatch.setattr(mmc, "filter_records_by_edit_type", lambda recs, include_edited=False: recs)
+    monkeypatch.setattr(mmc, "extract_status_columns", lambda _recs: ["Status A"])
+    monkeypatch.setattr(mmc, "filter_ready_records", lambda recs, cols: recs)
+    monkeypatch.setattr(mmc, "update_statuses", lambda recs, cols: 1)
+    monkeypatch.setattr(mmc, "move_file", lambda *_a, **_k: None)
+
+    saved = {}
+    monkeypatch.setattr(mmc, "save_csv", lambda data, path: saved.update({"data": data, "path": path}))
+
+    mmc.main()
+
+    assert saved["data"] == records

--- a/markmediaaschecked/tests/unit/test_markmediaaschecked_constants__sanity.py
+++ b/markmediaaschecked/tests/unit/test_markmediaaschecked_constants__sanity.py
@@ -1,0 +1,18 @@
+"""
+Unit tests for markmediaascheckedlib/constants.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "markmediaaschecked"
+sys.path.insert(0, str(package_root))
+
+from markmediaascheckedlib import constants
+
+
+def test_constants__types():
+    assert isinstance(constants.DEFAULT_PHOTO_CSV_FILE, str)
+    assert isinstance(constants.STATUS_READY, str)
+    assert isinstance(constants.STATUS_CHECKED, str)

--- a/markmediaaschecked/tests/unit/test_shared_csv_handler__scenarios.py
+++ b/markmediaaschecked/tests/unit/test_shared_csv_handler__scenarios.py
@@ -1,0 +1,76 @@
+"""
+Unit tests for markmediaaschecked/shared/csv_handler.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "markmediaaschecked"
+sys.path.insert(0, str(package_root))
+
+import shared.csv_handler as csv_handler
+
+
+def test_load_csv__success(monkeypatch):
+    monkeypatch.setattr(csv_handler, "detect_encoding", lambda _p: "utf-8")
+
+    class DummyDf:
+        def to_dict(self, orient="records"):
+            return [{"a": 1}]
+
+    monkeypatch.setattr(csv_handler.pd, "read_csv", lambda *_a, **_k: DummyDf())
+
+    data, encoding = csv_handler.load_csv("file.csv")
+    assert data == [{"a": 1}]
+    assert encoding == "utf-8"
+
+
+def test_load_csv__failure(monkeypatch):
+    monkeypatch.setattr(csv_handler, "detect_encoding", lambda _p: "utf-8")
+    monkeypatch.setattr(csv_handler.pd, "read_csv", lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("boom")))
+
+    try:
+        csv_handler.load_csv("file.csv")
+    except SystemExit as exc:
+        assert exc.code == 1
+    else:
+        raise AssertionError("Expected SystemExit")
+
+
+def test_save_csv__success(monkeypatch, tmp_path):
+    file_path = tmp_path / "data.csv"
+    file_path.write_text("a,b\n1,2\n", encoding="utf-8")
+
+    called = []
+    monkeypatch.setattr(csv_handler.shutil, "copy", lambda *_a, **_k: called.append(True))
+
+    class DummyDf:
+        def __init__(self, data):
+            self.data = data
+
+        def to_csv(self, *_a, **_k):
+            called.append("saved")
+
+    monkeypatch.setattr(csv_handler.pd, "DataFrame", lambda data: DummyDf(data))
+
+    csv_handler.save_csv([{"a": 1}], str(file_path), "utf-8")
+    assert "saved" in called
+
+
+def test_save_csv__failure(monkeypatch, tmp_path):
+    file_path = tmp_path / "data.csv"
+    file_path.write_text("a,b\n1,2\n", encoding="utf-8")
+
+    monkeypatch.setattr(csv_handler.shutil, "copy", lambda *_a, **_k: None)
+    monkeypatch.setattr(csv_handler.pd, "DataFrame", lambda _data: (_ for _ in ()).throw(RuntimeError("boom")))
+
+    try:
+        csv_handler.save_csv([{"a": 1}], str(file_path), "utf-8")
+    except SystemExit as exc:
+        assert exc.code == 1
+    else:
+        raise AssertionError("Expected SystemExit")

--- a/markmediaaschecked/tests/unit/test_shared_csv_sanitizer__scenarios.py
+++ b/markmediaaschecked/tests/unit/test_shared_csv_sanitizer__scenarios.py
@@ -1,0 +1,21 @@
+"""
+Unit tests for markmediaaschecked/shared/csv_sanitizer.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "markmediaaschecked"
+sys.path.insert(0, str(package_root))
+
+from shared.csv_sanitizer import sanitize_field, is_dangerous
+
+
+def test_sanitize_field__dangerous_prefix():
+    assert sanitize_field("=1+1") == "'=1+1"
+
+
+def test_is_dangerous__safe_and_unsafe():
+    assert is_dangerous("=1+1") is True
+    assert is_dangerous("safe") is False

--- a/markmediaaschecked/tests/unit/test_shared_file_operations__scenarios.py
+++ b/markmediaaschecked/tests/unit/test_shared_file_operations__scenarios.py
@@ -1,0 +1,22 @@
+"""
+Unit tests for markmediaaschecked/shared/file_operations.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "markmediaaschecked"
+sys.path.insert(0, str(package_root))
+
+import shared.file_operations as file_ops
+
+
+def test_copy_file__creates_dest_dir(tmp_path):
+    src = tmp_path / "src.txt"
+    src.write_text("x", encoding="utf-8")
+    dest = tmp_path / "out" / "dest.txt"
+
+    file_ops.copy_file(str(src), str(dest), overwrite=True)
+
+    assert dest.exists()

--- a/markmediaaschecked/tests/unit/test_shared_hash_utils__scenarios.py
+++ b/markmediaaschecked/tests/unit/test_shared_hash_utils__scenarios.py
@@ -1,0 +1,33 @@
+"""
+Unit tests for markmediaaschecked/shared/hash_utils.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "markmediaaschecked"
+sys.path.insert(0, str(package_root))
+
+import shared.hash_utils as hash_utils
+
+
+def test_compute_file_hash__md5(tmp_path):
+    file_path = tmp_path / "data.txt"
+    file_path.write_text("abc", encoding="utf-8")
+
+    result = hash_utils.compute_file_hash(str(file_path), method="md5")
+    assert len(result) == 32
+
+
+def test_compute_file_hash__xxhash_fallback(monkeypatch, tmp_path):
+    file_path = tmp_path / "data.txt"
+    file_path.write_text("abc", encoding="utf-8")
+
+    monkeypatch.setattr(hash_utils, "XXHASH_AVAILABLE", False)
+    hash_utils._xxhash_warning_logged = False
+
+    result = hash_utils.compute_file_hash(str(file_path), method="xxhash64")
+    assert len(result) == 32

--- a/markmediaaschecked/tests/unit/test_shared_logging_config__scenarios.py
+++ b/markmediaaschecked/tests/unit/test_shared_logging_config__scenarios.py
@@ -1,0 +1,37 @@
+"""
+Unit tests for markmediaaschecked/shared/logging_config.py.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "markmediaaschecked"
+sys.path.insert(0, str(package_root))
+
+import shared.logging_config as logging_config
+
+
+def test_setup_logging__configures_handlers(monkeypatch):
+    fake_json = io.StringIO('{"DEBUG":"white","INFO":"green","WARNING":"yellow","ERROR":"red","CRITICAL":"red"}')
+    monkeypatch.setattr(logging_config, "open", lambda *_a, **_k: fake_json)
+
+    class DummyFormatter:
+        def __init__(self, *_a, **_k):
+            return None
+
+    class DummyHandler:
+        def __init__(self, *_a, **_k):
+            self.formatter = None
+
+        def setFormatter(self, formatter):
+            self.formatter = formatter
+
+    monkeypatch.setattr(logging_config.colorlog, "ColoredFormatter", DummyFormatter)
+    monkeypatch.setattr(logging_config.logging, "StreamHandler", lambda: DummyHandler())
+    monkeypatch.setattr(logging_config.logging, "FileHandler", lambda *_a, **_k: DummyHandler())
+
+    logging_config.setup_logging(debug=True, log_file="log.txt")

--- a/markmediaaschecked/tests/unit/test_shared_modules__scenarios.py
+++ b/markmediaaschecked/tests/unit/test_shared_modules__scenarios.py
@@ -1,0 +1,49 @@
+"""
+Unit tests for markmediaaschecked/shared modules.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "markmediaaschecked"
+sys.path.insert(0, str(package_root))
+
+import shared.csv_handler as csv_handler
+import shared.hash_utils as hash_utils
+import shared.logging_config as logging_config
+import shared.utils as utils
+
+
+def test_csv_handler__import():
+    assert callable(csv_handler.load_csv)
+
+
+def test_hash_utils__md5(tmp_path):
+    data_file = tmp_path / "data.bin"
+    data_file.write_bytes(b"abc")
+    assert len(hash_utils.compute_file_hash(str(data_file), method="md5")) == 32
+
+
+def test_logging_config__missing_config_raises(monkeypatch):
+    monkeypatch.setattr(logging_config, "open", lambda *_a, **_k: (_ for _ in ()).throw(OSError("missing")))
+    with pytest.raises(Exception):
+        logging_config.setup_logging()
+
+
+def test_utils__get_log_filename(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["C:/tools/run_me.py"])
+
+    class DummyDateTime:
+        @classmethod
+        def now(cls):
+            class Dummy:
+                def strftime(self, _fmt):
+                    return "2020-01-01_12-00-00"
+
+            return Dummy()
+
+    monkeypatch.setattr(utils, "datetime", DummyDateTime)
+    assert utils.get_log_filename("C:/logs").endswith("run_me_Log_2020-01-01_12-00-00.log")

--- a/markmediaaschecked/tests/unit/test_shared_utils__scenarios.py
+++ b/markmediaaschecked/tests/unit/test_shared_utils__scenarios.py
@@ -1,0 +1,44 @@
+"""
+Unit tests for markmediaaschecked/shared/utils.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "markmediaaschecked"
+sys.path.insert(0, str(package_root))
+
+import shared.utils as utils
+
+
+def test_get_script_name__uses_argv(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["C:/tools/run_me.py"])
+    assert utils.get_script_name() == "run_me"
+
+
+def test_get_log_filename__formats(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["C:/tools/run_me.py"])
+
+    class DummyDateTime:
+        @classmethod
+        def now(cls):
+            class Dummy:
+                def strftime(self, _fmt):
+                    return "2020-01-01_12-00-00"
+
+            return Dummy()
+
+    monkeypatch.setattr(utils, "datetime", DummyDateTime)
+    result = utils.get_log_filename("C:/logs")
+    assert result.endswith("run_me_Log_2020-01-01_12-00-00.log")
+
+
+def test_detect_encoding__uses_chardet(monkeypatch, tmp_path):
+    file_path = tmp_path / "data.txt"
+    file_path.write_bytes(b"abc")
+
+    monkeypatch.setattr(utils.chardet, "detect", lambda _data: {"encoding": "utf-8"})
+    assert utils.detect_encoding(str(file_path)) == "utf-8"

--- a/markphotomediaapprovalstatus/tests/integration/test_process_approval_records__pipeline.py
+++ b/markphotomediaapprovalstatus/tests/integration/test_process_approval_records__pipeline.py
@@ -1,0 +1,47 @@
+"""
+Integration tests for process_approval_records workflow.
+"""
+
+import sys
+import types
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "markphotomediaapprovalstatus"
+sys.path.insert(0, str(package_root))
+
+from markphotomediaapprovalstatuslib.constants import BANKS, STATUS_CHECKED, STATUS_APPROVED
+from markphotomediaapprovalstatuslib.media_helper import process_approval_records
+
+
+def test_process_approval_records_updates_and_saves(tmp_path, monkeypatch):
+    media_path = tmp_path / "photo.jpg"
+    media_path.write_bytes(b"data")
+
+    bank = BANKS[0]
+    status_column = f"{bank} status"
+
+    record = {"Soubor": "photo.jpg", "Cesta": str(media_path), status_column: STATUS_CHECKED}
+    data = [record]
+
+    saved = {"count": 0}
+
+    def fake_show_media_viewer(_path, _record, callback, target_bank):
+        assert target_bank == bank
+        callback(STATUS_APPROVED)
+
+    monkeypatch.setattr(
+        "markphotomediaapprovalstatuslib.media_helper.save_csv_with_backup",
+        lambda *_a, **_k: saved.__setitem__("count", saved["count"] + 1),
+    )
+    monkeypatch.setattr(
+        "markphotomediaapprovalstatuslib.media_helper.os.path.exists",
+        lambda _p: True,
+    )
+    dummy_viewer = types.SimpleNamespace(show_media_viewer=fake_show_media_viewer)
+    monkeypatch.setitem(sys.modules, "markphotomediaapprovalstatuslib.media_viewer", dummy_viewer)
+
+    changed = process_approval_records(data, data, str(tmp_path / "out.csv"))
+    assert changed is True
+    assert record[status_column] == STATUS_APPROVED
+    assert saved["count"] == 1

--- a/markphotomediaapprovalstatus/tests/performance/test_filter_records_by_bank_status__bulk.py
+++ b/markphotomediaapprovalstatus/tests/performance/test_filter_records_by_bank_status__bulk.py
@@ -1,0 +1,21 @@
+"""
+Performance-oriented tests for filtering bank status records.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "markphotomediaapprovalstatus"
+sys.path.insert(0, str(package_root))
+
+from markphotomediaapprovalstatuslib.constants import BANKS, STATUS_CHECKED
+from markphotomediaapprovalstatuslib.status_handler import filter_records_by_bank_status
+
+
+def test_filter_records_by_bank_status_bulk():
+    bank = BANKS[0]
+    status_column = f"{bank} status"
+    records = [{status_column: STATUS_CHECKED} for _ in range(400)]
+    filtered = filter_records_by_bank_status(records, bank, STATUS_CHECKED)
+    assert len(filtered) == 400

--- a/markphotomediaapprovalstatus/tests/security/test_process_approval_records__missing_file.py
+++ b/markphotomediaapprovalstatus/tests/security/test_process_approval_records__missing_file.py
@@ -1,0 +1,35 @@
+"""
+Security-focused tests for handling missing files in approval workflow.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "markphotomediaapprovalstatus"
+sys.path.insert(0, str(package_root))
+
+from markphotomediaapprovalstatuslib.constants import BANKS, STATUS_CHECKED
+from markphotomediaapprovalstatuslib.media_helper import process_approval_records
+
+
+def test_process_approval_records_skips_missing_files(monkeypatch):
+    bank = BANKS[0]
+    status_column = f"{bank} status"
+
+    record = {"Soubor": "missing.jpg", "Cesta": "X:/missing.jpg", status_column: STATUS_CHECKED}
+    data = [record]
+
+    saved = {"count": 0}
+    monkeypatch.setattr(
+        "markphotomediaapprovalstatuslib.media_helper.save_csv_with_backup",
+        lambda *_a, **_k: saved.__setitem__("count", saved["count"] + 1),
+    )
+    monkeypatch.setattr(
+        "markphotomediaapprovalstatuslib.media_helper.os.path.exists",
+        lambda _p: False,
+    )
+
+    changed = process_approval_records(data, data, "out.csv")
+    assert changed is False
+    assert saved["count"] == 0

--- a/markphotomediaapprovalstatus/tests/unit/__init__.py
+++ b/markphotomediaapprovalstatus/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests package for markphotomediaapprovalstatus."""

--- a/markphotomediaapprovalstatus/tests/unit/test_markphotomediaapprovalstatus__main__scenarios.py
+++ b/markphotomediaapprovalstatus/tests/unit/test_markphotomediaapprovalstatus__main__scenarios.py
@@ -1,0 +1,45 @@
+"""
+Unit tests for markphotomediaapprovalstatus.py.
+"""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "markphotomediaapprovalstatus"
+sys.path.insert(0, str(package_root))
+
+import markphotomediaapprovalstatus as mmp
+
+
+def make_args(tmp_path, **overrides):
+    defaults = dict(
+        csv_path=str(tmp_path / "input.csv"),
+        log_dir=str(tmp_path / "logs"),
+        debug=False,
+        include_edited=False,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def test_parse_arguments__defaults(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["markphotomediaapprovalstatus.py"])
+    args = mmp.parse_arguments()
+    assert args.csv_path
+
+
+def test_main__load_error_returns(monkeypatch, tmp_path):
+    args = make_args(tmp_path)
+    monkeypatch.setattr(mmp, "parse_arguments", lambda: args)
+    monkeypatch.setattr(mmp, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(mmp, "get_log_filename", lambda _p: "log.txt")
+    monkeypatch.setattr(mmp, "setup_logging", lambda **_k: None)
+
+    def fail_load(_p):
+        raise OSError("fail")
+
+    monkeypatch.setattr(mmp, "load_csv", fail_load)
+
+    assert mmp.main() is None

--- a/markphotomediaapprovalstatus/tests/unit/test_markphotomediaapprovalstatus_constants__sanity.py
+++ b/markphotomediaapprovalstatus/tests/unit/test_markphotomediaapprovalstatus_constants__sanity.py
@@ -1,0 +1,18 @@
+"""
+Unit tests for markphotomediaapprovalstatuslib/constants.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "markphotomediaapprovalstatus"
+sys.path.insert(0, str(package_root))
+
+from markphotomediaapprovalstatuslib import constants
+
+
+def test_constants__types():
+    assert isinstance(constants.DEFAULT_PHOTO_CSV_PATH, str)
+    assert isinstance(constants.DEFAULT_LOG_DIR, str)
+    assert isinstance(constants.STATUS_CHECKED, str)

--- a/markphotomediaapprovalstatus/tests/unit/test_media_helper__scenarios.py
+++ b/markphotomediaapprovalstatus/tests/unit/test_media_helper__scenarios.py
@@ -1,0 +1,32 @@
+"""
+Unit tests for markphotomediaapprovalstatuslib/media_helper.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "markphotomediaapprovalstatus"
+sys.path.insert(0, str(package_root))
+
+from markphotomediaapprovalstatuslib.media_helper import (
+    is_video_file,
+    is_jpg_file,
+    is_media_file,
+)
+
+
+def test_is_video_file():
+    assert is_video_file("video.mp4") is True
+    assert is_video_file("image.jpg") is False
+
+
+def test_is_jpg_file():
+    assert is_jpg_file("photo.jpg") is True
+    assert is_jpg_file("photo.png") is False
+
+
+def test_is_media_file():
+    assert is_media_file("photo.jpg") is True
+    assert is_media_file("clip.mp4") is True
+    assert is_media_file("doc.txt") is False

--- a/markphotomediaapprovalstatus/tests/unit/test_media_viewer__import.py
+++ b/markphotomediaapprovalstatus/tests/unit/test_media_viewer__import.py
@@ -1,0 +1,14 @@
+"""
+Import smoke test for media_viewer module.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "markphotomediaapprovalstatus"
+sys.path.insert(0, str(package_root))
+
+
+def test_import_media_viewer():
+    import markphotomediaapprovalstatuslib.media_viewer  # noqa: F401

--- a/markphotomediaapprovalstatus/tests/unit/test_shared_csv_sanitizer__scenarios.py
+++ b/markphotomediaapprovalstatus/tests/unit/test_shared_csv_sanitizer__scenarios.py
@@ -1,0 +1,21 @@
+"""
+Unit tests for markphotomediaapprovalstatus/shared/csv_sanitizer.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "markphotomediaapprovalstatus"
+sys.path.insert(0, str(package_root))
+
+from shared.csv_sanitizer import sanitize_field, is_dangerous
+
+
+def test_sanitize_field__dangerous_prefix():
+    assert sanitize_field("=1+1") == "'=1+1"
+
+
+def test_is_dangerous__safe_and_unsafe():
+    assert is_dangerous("=1+1") is True
+    assert is_dangerous("safe") is False

--- a/markphotomediaapprovalstatus/tests/unit/test_shared_file_operations__scenarios.py
+++ b/markphotomediaapprovalstatus/tests/unit/test_shared_file_operations__scenarios.py
@@ -1,0 +1,22 @@
+"""
+Unit tests for markphotomediaapprovalstatus/shared/file_operations.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "markphotomediaapprovalstatus"
+sys.path.insert(0, str(package_root))
+
+import shared.file_operations as file_ops
+
+
+def test_copy_file__creates_dest_dir(tmp_path):
+    src = tmp_path / "src.txt"
+    src.write_text("x", encoding="utf-8")
+    dest = tmp_path / "out" / "dest.txt"
+
+    file_ops.copy_file(str(src), str(dest), overwrite=True)
+
+    assert dest.exists()

--- a/markphotomediaapprovalstatus/tests/unit/test_shared_hash_utils__scenarios.py
+++ b/markphotomediaapprovalstatus/tests/unit/test_shared_hash_utils__scenarios.py
@@ -1,0 +1,33 @@
+"""
+Unit tests for markphotomediaapprovalstatus/shared/hash_utils.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "markphotomediaapprovalstatus"
+sys.path.insert(0, str(package_root))
+
+import shared.hash_utils as hash_utils
+
+
+def test_compute_file_hash__md5(tmp_path):
+    file_path = tmp_path / "data.txt"
+    file_path.write_text("abc", encoding="utf-8")
+
+    result = hash_utils.compute_file_hash(str(file_path), method="md5")
+    assert len(result) == 32
+
+
+def test_compute_file_hash__xxhash_fallback(monkeypatch, tmp_path):
+    file_path = tmp_path / "data.txt"
+    file_path.write_text("abc", encoding="utf-8")
+
+    monkeypatch.setattr(hash_utils, "XXHASH_AVAILABLE", False)
+    hash_utils._xxhash_warning_logged = False
+
+    result = hash_utils.compute_file_hash(str(file_path), method="xxhash64")
+    assert len(result) == 32

--- a/markphotomediaapprovalstatus/tests/unit/test_shared_logging_config__scenarios.py
+++ b/markphotomediaapprovalstatus/tests/unit/test_shared_logging_config__scenarios.py
@@ -1,0 +1,37 @@
+"""
+Unit tests for markphotomediaapprovalstatus/shared/logging_config.py.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "markphotomediaapprovalstatus"
+sys.path.insert(0, str(package_root))
+
+import shared.logging_config as logging_config
+
+
+def test_setup_logging__configures_handlers(monkeypatch):
+    fake_json = io.StringIO('{"DEBUG":"white","INFO":"green","WARNING":"yellow","ERROR":"red","CRITICAL":"red"}')
+    monkeypatch.setattr(logging_config, "open", lambda *_a, **_k: fake_json)
+
+    class DummyFormatter:
+        def __init__(self, *_a, **_k):
+            return None
+
+    class DummyHandler:
+        def __init__(self, *_a, **_k):
+            self.formatter = None
+
+        def setFormatter(self, formatter):
+            self.formatter = formatter
+
+    monkeypatch.setattr(logging_config.colorlog, "ColoredFormatter", DummyFormatter)
+    monkeypatch.setattr(logging_config.logging, "StreamHandler", lambda: DummyHandler())
+    monkeypatch.setattr(logging_config.logging, "FileHandler", lambda *_a, **_k: DummyHandler())
+
+    logging_config.setup_logging(debug=False, log_file="log.txt")

--- a/markphotomediaapprovalstatus/tests/unit/test_shared_modules__scenarios.py
+++ b/markphotomediaapprovalstatus/tests/unit/test_shared_modules__scenarios.py
@@ -1,0 +1,44 @@
+"""
+Unit tests for markphotomediaapprovalstatus/shared modules.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "markphotomediaapprovalstatus"
+sys.path.insert(0, str(package_root))
+
+import shared.hash_utils as hash_utils
+import shared.logging_config as logging_config
+import shared.utils as utils
+
+
+def test_hash_utils__md5(tmp_path):
+    data_file = tmp_path / "data.bin"
+    data_file.write_bytes(b"abc")
+    assert len(hash_utils.compute_file_hash(str(data_file), method="md5")) == 32
+
+
+def test_logging_config__missing_config_raises(monkeypatch):
+    monkeypatch.setattr(logging_config, "open", lambda *_a, **_k: (_ for _ in ()).throw(OSError("missing")))
+    with pytest.raises(Exception):
+        logging_config.setup_logging()
+
+
+def test_utils__get_log_filename(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["C:/tools/run_me.py"])
+
+    class DummyDateTime:
+        @classmethod
+        def now(cls):
+            class Dummy:
+                def strftime(self, _fmt):
+                    return "2020-01-01_12-00-00"
+
+            return Dummy()
+
+    monkeypatch.setattr(utils, "datetime", DummyDateTime)
+    assert utils.get_log_filename("C:/logs").endswith("run_me_Log_2020-01-01_12-00-00.log")

--- a/markphotomediaapprovalstatus/tests/unit/test_shared_utils__scenarios.py
+++ b/markphotomediaapprovalstatus/tests/unit/test_shared_utils__scenarios.py
@@ -1,0 +1,36 @@
+"""
+Unit tests for markphotomediaapprovalstatus/shared/utils.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "markphotomediaapprovalstatus"
+sys.path.insert(0, str(package_root))
+
+import shared.utils as utils
+
+
+def test_get_script_name__uses_argv(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["C:/tools/run_me.py"])
+    assert utils.get_script_name() == "run_me"
+
+
+def test_get_log_filename__formats(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["C:/tools/run_me.py"])
+
+    class DummyDateTime:
+        @classmethod
+        def now(cls):
+            class Dummy:
+                def strftime(self, _fmt):
+                    return "2020-01-01_12-00-00"
+
+            return Dummy()
+
+    monkeypatch.setattr(utils, "datetime", DummyDateTime)
+    result = utils.get_log_filename("C:/logs")
+    assert result.endswith("run_me_Log_2020-01-01_12-00-00.log")

--- a/markphotomediaapprovalstatus/tests/unit/test_status_handler__scenarios.py
+++ b/markphotomediaapprovalstatus/tests/unit/test_status_handler__scenarios.py
@@ -1,0 +1,72 @@
+"""
+Unit tests for markphotomediaapprovalstatuslib/status_handler.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "markphotomediaapprovalstatus"
+sys.path.insert(0, str(package_root))
+
+from markphotomediaapprovalstatuslib import constants
+from markphotomediaapprovalstatuslib.status_handler import (
+    extract_status_columns,
+    filter_records_by_status,
+    filter_records_by_bank_status,
+    find_sharpen_for_original,
+    update_sharpen_status,
+    is_edited_photo,
+    filter_records_by_edit_type,
+)
+
+
+def test_extract_status_columns__case_insensitive():
+    records = [{"Shutterstock Status": "x", "Other": "y"}]
+    cols = extract_status_columns(records)
+    assert "Shutterstock Status" in cols
+
+
+def test_filter_records_by_status__selects_checked():
+    records = [{"Status A": constants.STATUS_CHECKED}, {"Status A": "other"}]
+    result = filter_records_by_status(records, constants.STATUS_CHECKED)
+    assert result == [records[0]]
+
+
+def test_filter_records_by_bank_status__matches_column():
+    records = [{"Bank status": constants.STATUS_CHECKED}]
+    result = filter_records_by_bank_status(records, "Bank", constants.STATUS_CHECKED)
+    assert result == [records[0]]
+
+
+def test_find_sharpen_for_original__finds_match():
+    records = [
+        {constants.COL_FILE: "photo.jpg"},
+        {constants.COL_FILE: "photo_sharpen.jpg"},
+    ]
+    assert find_sharpen_for_original("photo.jpg", records) == records[1]
+
+
+def test_update_sharpen_status__approved_sets_unused():
+    original = {constants.COL_FILE: "photo.jpg", constants.COL_ORIGINAL: constants.ORIGINAL_YES}
+    sharpen = {constants.COL_FILE: "photo_sharpen.jpg", "Bank status": constants.STATUS_BACKUP}
+    records = [original, sharpen]
+
+    changed = update_sharpen_status(original, records, "Bank", constants.STATUS_APPROVED)
+
+    assert changed is True
+    assert sharpen["Bank status"] == constants.STATUS_UNUSED
+
+
+def test_is_edited_photo__detects_tag():
+    record = {constants.COL_FILE: "photo_bw.jpg"}
+    assert is_edited_photo(record) is True
+
+
+def test_filter_records_by_edit_type__excludes_sharpen():
+    records = [
+        {constants.COL_FILE: "photo_sharpen.jpg"},
+        {constants.COL_FILE: "photo.jpg"},
+    ]
+    filtered = filter_records_by_edit_type(records, include_edited=False)
+    assert filtered == [records[1]]

--- a/pullnewmediatounsorted/tests/integration/test_main_pipeline__calls.py
+++ b/pullnewmediatounsorted/tests/integration/test_main_pipeline__calls.py
@@ -1,0 +1,75 @@
+"""
+Integration tests for pullnewmediatounsorted main call flow.
+"""
+
+import types
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "pullnewmediatounsorted"
+sys.path.insert(0, str(package_root))
+
+import pullnewmediatounsorted
+
+
+def test_main_calls_core_steps(monkeypatch):
+    args = types.SimpleNamespace(
+        raid_drive="X:/raid",
+        dropbox="X:/dropbox",
+        gdrive="X:/gdrive",
+        onedrive_auto="X:/auto",
+        onedrive_manual="X:/manual",
+        snapbridge="X:/snap",
+        screens_onedrive="X:/screens1",
+        screens_dropbox="X:/screens2",
+        account_folder="X:/account",
+        target="X:/target",
+        target_screen="X:/target_screen",
+        final_target="X:/final",
+        log_dir="X:/logs",
+        debug=False,
+        index_prefix="PICT",
+        index_width=4,
+        index_max=10,
+    )
+
+    calls = {"unify": 0, "replace": 0, "normalize": 0, "copy": 0, "flatten": 0}
+
+    monkeypatch.setattr(pullnewmediatounsorted, "parse_arguments", lambda: args)
+    monkeypatch.setattr(pullnewmediatounsorted, "setup_logging", lambda **_k: None)
+    monkeypatch.setattr(pullnewmediatounsorted, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(pullnewmediatounsorted, "get_log_filename", lambda _p: "log.txt")
+    monkeypatch.setattr(
+        pullnewmediatounsorted,
+        "unify_duplicate_files",
+        lambda *_a, **_k: calls.__setitem__("unify", calls["unify"] + 1),
+    )
+    monkeypatch.setattr(
+        pullnewmediatounsorted,
+        "replace_in_filenames",
+        lambda *_a, **_k: calls.__setitem__("replace", calls["replace"] + 1),
+    )
+    monkeypatch.setattr(
+        pullnewmediatounsorted,
+        "normalize_indexed_filenames",
+        lambda *_a, **_k: calls.__setitem__("normalize", calls["normalize"] + 1),
+    )
+    monkeypatch.setattr(
+        pullnewmediatounsorted,
+        "copy_folder",
+        lambda *_a, **_k: calls.__setitem__("copy", calls["copy"] + 1),
+    )
+    monkeypatch.setattr(
+        pullnewmediatounsorted,
+        "flatten_folder",
+        lambda *_a, **_k: calls.__setitem__("flatten", calls["flatten"] + 1),
+    )
+
+    pullnewmediatounsorted.main()
+
+    assert calls["unify"] > 0
+    assert calls["replace"] > 0
+    assert calls["normalize"] > 0
+    assert calls["copy"] > 0
+    assert calls["flatten"] == 2

--- a/pullnewmediatounsorted/tests/performance/test_replace_in_filenames__bulk.py
+++ b/pullnewmediatounsorted/tests/performance/test_replace_in_filenames__bulk.py
@@ -1,0 +1,23 @@
+"""
+Performance-oriented tests for bulk filename replacement.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "pullnewmediatounsorted"
+sys.path.insert(0, str(package_root))
+
+from pullnewmediatounsortedlib.renaming import replace_in_filenames
+
+
+def test_replace_in_filenames_bulk(tmp_path):
+    folder = tmp_path / "media"
+    folder.mkdir()
+    for i in range(50):
+        (folder / f"IMG_{i}_NIK.jpg").write_bytes(b"data")
+
+    replace_in_filenames(str(folder), "_NIK", "NIK_", recursive=True)
+
+    assert (folder / "IMG_1_NIK_.jpg").exists()

--- a/pullnewmediatounsorted/tests/security/test_screen_pattern__escapes_markers.py
+++ b/pullnewmediatounsorted/tests/security/test_screen_pattern__escapes_markers.py
@@ -1,0 +1,58 @@
+"""
+Security-focused tests for screenshot pattern escaping.
+"""
+
+import types
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "pullnewmediatounsorted"
+sys.path.insert(0, str(package_root))
+
+import pullnewmediatounsorted
+
+
+def test_pattern_escapes_markers(monkeypatch):
+    args = types.SimpleNamespace(
+        raid_drive="X:/raid",
+        dropbox="X:/dropbox",
+        gdrive="X:/gdrive",
+        onedrive_auto="X:/auto",
+        onedrive_manual="X:/manual",
+        snapbridge="X:/snap",
+        screens_onedrive="X:/screens1",
+        screens_dropbox="X:/screens2",
+        account_folder="X:/account",
+        target="X:/target",
+        target_screen="X:/target_screen",
+        final_target="X:/final",
+        log_dir="X:/logs",
+        debug=False,
+        index_prefix="PICT",
+        index_width=4,
+        index_max=10,
+    )
+
+    marker = "screen(shot)+"
+    monkeypatch.setattr(pullnewmediatounsorted, "SCREENSHOT_MARKERS", [marker])
+
+    captured = {"pattern": None}
+
+    monkeypatch.setattr(pullnewmediatounsorted, "parse_arguments", lambda: args)
+    monkeypatch.setattr(pullnewmediatounsorted, "setup_logging", lambda **_k: None)
+    monkeypatch.setattr(pullnewmediatounsorted, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(pullnewmediatounsorted, "get_log_filename", lambda _p: "log.txt")
+    monkeypatch.setattr(pullnewmediatounsorted, "unify_duplicate_files", lambda *_a, **_k: None)
+    monkeypatch.setattr(pullnewmediatounsorted, "replace_in_filenames", lambda *_a, **_k: None)
+    monkeypatch.setattr(pullnewmediatounsorted, "normalize_indexed_filenames", lambda *_a, **_k: None)
+    monkeypatch.setattr(pullnewmediatounsorted, "flatten_folder", lambda *_a, **_k: None)
+
+    def capture_copy_folder(_src, _dest, pattern=""):
+        captured["pattern"] = pattern
+
+    monkeypatch.setattr(pullnewmediatounsorted, "copy_folder", capture_copy_folder)
+
+    pullnewmediatounsorted.main()
+    assert "\\(" in captured["pattern"]
+    assert "\\+" in captured["pattern"]

--- a/pullnewmediatounsorted/tests/unit/test_name_utils__scenarios.py
+++ b/pullnewmediatounsorted/tests/unit/test_name_utils__scenarios.py
@@ -1,0 +1,25 @@
+"""
+Unit tests for pullnewmediatounsorted/shared/name_utils.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "pullnewmediatounsorted"
+sys.path.insert(0, str(package_root))
+
+from shared.name_utils import extract_numeric_suffix, generate_indexed_filename, find_next_available_number
+
+
+def test_extract_numeric_suffix__matches_prefix():
+    assert extract_numeric_suffix("PICT0001.jpg", prefix="PICT") == 1
+    assert extract_numeric_suffix("OTHER0001.jpg", prefix="PICT") is None
+
+
+def test_generate_indexed_filename__formats():
+    assert generate_indexed_filename(12, ".jpg", prefix="PICT", width=4) == "PICT0012.jpg"
+
+
+def test_find_next_available_number__returns_first_free():
+    assert find_next_available_number({1, 2, 3}, max_number=5) == 4

--- a/pullnewmediatounsorted/tests/unit/test_pullnewmediatounsorted__main__scenarios.py
+++ b/pullnewmediatounsorted/tests/unit/test_pullnewmediatounsorted__main__scenarios.py
@@ -1,0 +1,71 @@
+"""
+Unit tests for pullnewmediatounsorted.py.
+"""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "pullnewmediatounsorted"
+sys.path.insert(0, str(package_root))
+
+import pullnewmediatounsorted as pnu
+from pullnewmediatounsortedlib import constants
+
+
+def make_args(tmp_path, **overrides):
+    defaults = dict(
+        raid_drive=str(tmp_path / "raid"),
+        dropbox=str(tmp_path / "dropbox"),
+        gdrive=str(tmp_path / "gdrive"),
+        onedrive_auto=str(tmp_path / "od_auto"),
+        onedrive_manual=str(tmp_path / "od_manual"),
+        snapbridge=str(tmp_path / "snap"),
+        screens_onedrive=str(tmp_path / "screen_od"),
+        screens_dropbox=str(tmp_path / "screen_db"),
+        account_folder=str(tmp_path / "account"),
+        target=str(tmp_path / "target"),
+        target_screen=str(tmp_path / "target_screen"),
+        final_target=str(tmp_path / "final"),
+        log_dir=str(tmp_path / "logs"),
+        debug=False,
+        index_prefix="PICT",
+        index_width=4,
+        index_max=10,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def test_parse_arguments__defaults(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["pullnewmediatounsorted.py"])
+    args = pnu.parse_arguments()
+    assert args.raid_drive == constants.DEFAULT_RAID_DRIVE
+
+
+def test_main__calls_copy_and_flatten(monkeypatch, tmp_path):
+    args = make_args(tmp_path)
+    monkeypatch.setattr(pnu, "parse_arguments", lambda: args)
+    monkeypatch.setattr(pnu, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(pnu, "get_log_filename", lambda _p: "log.txt")
+    monkeypatch.setattr(pnu, "setup_logging", lambda **_k: None)
+
+    called = {"copy": 0, "flatten": 0}
+    monkeypatch.setattr(pnu, "unify_duplicate_files", lambda *_a, **_k: None)
+    monkeypatch.setattr(pnu, "replace_in_filenames", lambda *_a, **_k: None)
+    monkeypatch.setattr(pnu, "normalize_indexed_filenames", lambda *_a, **_k: None)
+
+    def fake_copy(*_a, **_k):
+        called["copy"] += 1
+
+    def fake_flatten(*_a, **_k):
+        called["flatten"] += 1
+
+    monkeypatch.setattr(pnu, "copy_folder", fake_copy)
+    monkeypatch.setattr(pnu, "flatten_folder", fake_flatten)
+
+    pnu.main()
+
+    assert called["copy"] > 0
+    assert called["flatten"] == 2

--- a/pullnewmediatounsorted/tests/unit/test_renaming__replace_in_filenames__scenarios.py
+++ b/pullnewmediatounsorted/tests/unit/test_renaming__replace_in_filenames__scenarios.py
@@ -1,0 +1,22 @@
+"""
+Unit tests for replace_in_filenames.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "pullnewmediatounsorted"
+sys.path.insert(0, str(package_root))
+
+from pullnewmediatounsortedlib.renaming import replace_in_filenames
+
+
+def test_replace_in_filenames__renames(tmp_path):
+    target = tmp_path / "photo_NIK.jpg"
+    target.write_text("x", encoding="utf-8")
+
+    replace_in_filenames(str(tmp_path), "_NIK", "NIK_", recursive=False)
+
+    assert not target.exists()
+    assert (tmp_path / "photoNIK_.jpg").exists()

--- a/pullnewmediatounsorted/tests/unit/test_shared_csv_sanitizer__scenarios.py
+++ b/pullnewmediatounsorted/tests/unit/test_shared_csv_sanitizer__scenarios.py
@@ -1,0 +1,21 @@
+"""
+Unit tests for pullnewmediatounsorted/shared/csv_sanitizer.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "pullnewmediatounsorted"
+sys.path.insert(0, str(package_root))
+
+from shared.csv_sanitizer import sanitize_field, is_dangerous
+
+
+def test_sanitize_field__dangerous_prefix():
+    assert sanitize_field("=1+1") == "'=1+1"
+
+
+def test_is_dangerous__safe_and_unsafe():
+    assert is_dangerous("=1+1") is True
+    assert is_dangerous("safe") is False

--- a/pullnewmediatounsorted/tests/unit/test_shared_exif_downloader__scenarios.py
+++ b/pullnewmediatounsorted/tests/unit/test_shared_exif_downloader__scenarios.py
@@ -1,0 +1,29 @@
+"""
+Unit tests for pullnewmediatounsorted/shared/exif_downloader.py.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "pullnewmediatounsorted"
+sys.path.insert(0, str(package_root))
+
+import shared.exif_downloader as exif_downloader
+
+
+def test_ensure_exiftool__returns_path_when_exists(monkeypatch):
+    monkeypatch.setattr(exif_downloader, "EXIFTOOL_PATH", "C:/Tools/exiftool.exe")
+    monkeypatch.setattr(exif_downloader.os.path, "exists", lambda _p: True)
+
+    assert exif_downloader.ensure_exiftool() == "C:/Tools/exiftool.exe"
+
+
+def test_ensure_exiftool__raises_when_missing(monkeypatch):
+    monkeypatch.setattr(exif_downloader, "EXIFTOOL_PATH", "C:/Tools/exiftool.exe")
+    monkeypatch.setattr(exif_downloader.os.path, "exists", lambda _p: False)
+
+    with pytest.raises(FileNotFoundError):
+        exif_downloader.ensure_exiftool()

--- a/pullnewmediatounsorted/tests/unit/test_shared_exif_handler__import.py
+++ b/pullnewmediatounsorted/tests/unit/test_shared_exif_handler__import.py
@@ -1,0 +1,14 @@
+"""
+Import smoke test for shared.exif_handler.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "pullnewmediatounsorted"
+sys.path.insert(0, str(package_root))
+
+
+def test_import_exif_handler():
+    import shared.exif_handler  # noqa: F401

--- a/pullnewmediatounsorted/tests/unit/test_shared_hash_utils__scenarios.py
+++ b/pullnewmediatounsorted/tests/unit/test_shared_hash_utils__scenarios.py
@@ -1,0 +1,33 @@
+"""
+Unit tests for pullnewmediatounsorted/shared/hash_utils.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "pullnewmediatounsorted"
+sys.path.insert(0, str(package_root))
+
+import shared.hash_utils as hash_utils
+
+
+def test_compute_file_hash__md5(tmp_path):
+    file_path = tmp_path / "data.txt"
+    file_path.write_text("abc", encoding="utf-8")
+
+    result = hash_utils.compute_file_hash(str(file_path), method="md5")
+    assert len(result) == 32
+
+
+def test_compute_file_hash__xxhash_fallback(monkeypatch, tmp_path):
+    file_path = tmp_path / "data.txt"
+    file_path.write_text("abc", encoding="utf-8")
+
+    monkeypatch.setattr(hash_utils, "XXHASH_AVAILABLE", False)
+    hash_utils._xxhash_warning_logged = False
+
+    result = hash_utils.compute_file_hash(str(file_path), method="xxhash64")
+    assert len(result) == 32

--- a/pullnewmediatounsorted/tests/unit/test_shared_logging_config__scenarios.py
+++ b/pullnewmediatounsorted/tests/unit/test_shared_logging_config__scenarios.py
@@ -1,0 +1,37 @@
+"""
+Unit tests for pullnewmediatounsorted/shared/logging_config.py.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "pullnewmediatounsorted"
+sys.path.insert(0, str(package_root))
+
+import shared.logging_config as logging_config
+
+
+def test_setup_logging__configures_handlers(monkeypatch):
+    fake_json = io.StringIO('{"DEBUG":"white","INFO":"green","WARNING":"yellow","ERROR":"red","CRITICAL":"red"}')
+    monkeypatch.setattr(logging_config, "open", lambda *_a, **_k: fake_json)
+
+    class DummyFormatter:
+        def __init__(self, *_a, **_k):
+            return None
+
+    class DummyHandler:
+        def __init__(self, *_a, **_k):
+            self.formatter = None
+
+        def setFormatter(self, formatter):
+            self.formatter = formatter
+
+    monkeypatch.setattr(logging_config.colorlog, "ColoredFormatter", DummyFormatter)
+    monkeypatch.setattr(logging_config.logging, "StreamHandler", lambda: DummyHandler())
+    monkeypatch.setattr(logging_config.logging, "FileHandler", lambda *_a, **_k: DummyHandler())
+
+    logging_config.setup_logging(debug=False, log_file="log.txt")

--- a/pullnewmediatounsorted/tests/unit/test_shared_modules__scenarios.py
+++ b/pullnewmediatounsorted/tests/unit/test_shared_modules__scenarios.py
@@ -1,0 +1,44 @@
+"""
+Unit tests for pullnewmediatounsorted/shared modules.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "pullnewmediatounsorted"
+sys.path.insert(0, str(package_root))
+
+import shared.hash_utils as hash_utils
+import shared.logging_config as logging_config
+import shared.utils as utils
+
+
+def test_hash_utils__md5(tmp_path):
+    data_file = tmp_path / "data.bin"
+    data_file.write_bytes(b"abc")
+    assert len(hash_utils.compute_file_hash(str(data_file), method="md5")) == 32
+
+
+def test_logging_config__missing_config_raises(monkeypatch):
+    monkeypatch.setattr(logging_config, "open", lambda *_a, **_k: (_ for _ in ()).throw(OSError("missing")))
+    with pytest.raises(Exception):
+        logging_config.setup_logging()
+
+
+def test_utils__get_log_filename(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["C:/tools/run_me.py"])
+
+    class DummyDateTime:
+        @classmethod
+        def now(cls):
+            class Dummy:
+                def strftime(self, _fmt):
+                    return "2020-01-01_12-00-00"
+
+            return Dummy()
+
+    monkeypatch.setattr(utils, "datetime", DummyDateTime)
+    assert utils.get_log_filename("C:/logs").endswith("run_me_Log_2020-01-01_12-00-00.log")

--- a/pullnewmediatounsorted/tests/unit/test_shared_utils__scenarios.py
+++ b/pullnewmediatounsorted/tests/unit/test_shared_utils__scenarios.py
@@ -1,0 +1,36 @@
+"""
+Unit tests for pullnewmediatounsorted/shared/utils.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "pullnewmediatounsorted"
+sys.path.insert(0, str(package_root))
+
+import shared.utils as utils
+
+
+def test_get_script_name__uses_argv(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["C:/tools/run_me.py"])
+    assert utils.get_script_name() == "run_me"
+
+
+def test_get_log_filename__formats(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["C:/tools/run_me.py"])
+
+    class DummyDateTime:
+        @classmethod
+        def now(cls):
+            class Dummy:
+                def strftime(self, _fmt):
+                    return "2020-01-01_12-00-00"
+
+            return Dummy()
+
+    monkeypatch.setattr(utils, "datetime", DummyDateTime)
+    result = utils.get_log_filename("C:/logs")
+    assert result.endswith("run_me_Log_2020-01-01_12-00-00.log")

--- a/removealreadysortedout/tests/integration/test_main_pipeline__calls.py
+++ b/removealreadysortedout/tests/integration/test_main_pipeline__calls.py
@@ -1,0 +1,68 @@
+"""
+Integration tests for remove_already_sorted_out main call flow.
+"""
+
+import types
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "removealreadysortedout"
+sys.path.insert(0, str(package_root))
+
+import remove_already_sorted_out
+
+
+def test_main_calls_expected_steps(monkeypatch):
+    args = types.SimpleNamespace(
+        unsorted_folder="X:/unsorted",
+        target_folder="X:/target",
+        log_dir="X:/logs",
+        overwrite=False,
+        debug=False,
+        index_prefix="PICT",
+        index_width=4,
+        index_max=10,
+    )
+
+    calls = {"remove_ini": 0, "unify": 0, "replace": 0, "normalize": 0, "handle": 0}
+
+    monkeypatch.setattr(remove_already_sorted_out, "parse_arguments", lambda: args)
+    monkeypatch.setattr(remove_already_sorted_out, "setup_logging", lambda **_k: None)
+    monkeypatch.setattr(remove_already_sorted_out, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(remove_already_sorted_out, "get_log_filename", lambda _p: "log.txt")
+    monkeypatch.setattr(
+        remove_already_sorted_out,
+        "remove_desktop_ini",
+        lambda *_a, **_k: calls.__setitem__("remove_ini", calls["remove_ini"] + 1),
+    )
+    monkeypatch.setattr(
+        remove_already_sorted_out,
+        "unify_duplicate_files",
+        lambda *_a, **_k: calls.__setitem__("unify", calls["unify"] + 1),
+    )
+    monkeypatch.setattr(
+        remove_already_sorted_out,
+        "replace_in_filenames",
+        lambda *_a, **_k: calls.__setitem__("replace", calls["replace"] + 1),
+    )
+    monkeypatch.setattr(
+        remove_already_sorted_out,
+        "normalize_indexed_filenames",
+        lambda *_a, **_k: calls.__setitem__("normalize", calls["normalize"] + 1),
+    )
+    monkeypatch.setattr(remove_already_sorted_out, "list_files", lambda *_a, **_k: ["a.jpg"])
+    monkeypatch.setattr(remove_already_sorted_out, "get_target_files_map", lambda *_a, **_k: {"a.jpg": ["t"]})
+    monkeypatch.setattr(remove_already_sorted_out, "find_duplicates", lambda *_a, **_k: {"a.jpg": ["t"]})
+    monkeypatch.setattr(
+        remove_already_sorted_out,
+        "handle_duplicate",
+        lambda *_a, **_k: calls.__setitem__("handle", calls["handle"] + 1),
+    )
+
+    remove_already_sorted_out.main()
+    assert calls["remove_ini"] == 1
+    assert calls["unify"] == 2
+    assert calls["replace"] == 2
+    assert calls["normalize"] > 0
+    assert calls["handle"] == 1

--- a/removealreadysortedout/tests/performance/test_find_duplicates__bulk.py
+++ b/removealreadysortedout/tests/performance/test_find_duplicates__bulk.py
@@ -1,0 +1,19 @@
+"""
+Performance-oriented tests for duplicate detection.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "removealreadysortedout"
+sys.path.insert(0, str(package_root))
+
+from removealreadysortedoutlib.removal_operations import find_duplicates
+
+
+def test_find_duplicates_bulk():
+    unsorted_files = [f"C:/unsorted/file_{i}.jpg" for i in range(500)]
+    target_map = {f"file_{i}.jpg": [f"C:/target/file_{i}.jpg"] for i in range(0, 500, 2)}
+    duplicates = find_duplicates(unsorted_files, target_map)
+    assert len(duplicates) == 250

--- a/removealreadysortedout/tests/security/test_should_replace_file__zero_source.py
+++ b/removealreadysortedout/tests/security/test_should_replace_file__zero_source.py
@@ -1,0 +1,21 @@
+"""
+Security-focused tests for replacement guard logic.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "removealreadysortedout"
+sys.path.insert(0, str(package_root))
+
+from removealreadysortedoutlib.removal_operations import should_replace_file
+
+
+def test_should_replace_file_rejects_empty_source(tmp_path):
+    source = tmp_path / "source.jpg"
+    target = tmp_path / "target.jpg"
+    source.write_bytes(b"")
+    target.write_bytes(b"data")
+
+    assert should_replace_file(str(source), str(target)) is False

--- a/removealreadysortedout/tests/unit/test_removal_operations__scenarios.py
+++ b/removealreadysortedout/tests/unit/test_removal_operations__scenarios.py
@@ -1,0 +1,44 @@
+"""
+Unit tests for removealreadysortedoutlib/removal_operations.py.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "removealreadysortedout"
+sys.path.insert(0, str(package_root))
+
+import removealreadysortedoutlib.removal_operations as ops
+
+
+def test_get_target_files_map__collects(tmp_path):
+    file_a = tmp_path / "a.txt"
+    file_a.write_text("x", encoding="utf-8")
+    result = ops.get_target_files_map(str(tmp_path))
+    assert "a.txt" in result
+
+
+def test_find_duplicates__matches():
+    duplicates = ops.find_duplicates(["/tmp/a.txt"], {"a.txt": ["/target/a.txt"]})
+    assert "/tmp/a.txt" in duplicates
+
+
+def test_should_replace_file__target_zero_size(tmp_path):
+    source = tmp_path / "source.txt"
+    target = tmp_path / "target.txt"
+    source.write_text("data", encoding="utf-8")
+    target.write_text("", encoding="utf-8")
+
+    assert ops.should_replace_file(str(source), str(target)) is True
+
+
+def test_remove_desktop_ini__removes(tmp_path):
+    desktop_ini = tmp_path / "desktop.ini"
+    desktop_ini.write_text("x", encoding="utf-8")
+
+    ops.remove_desktop_ini(str(tmp_path))
+
+    assert not desktop_ini.exists()

--- a/removealreadysortedout/tests/unit/test_remove_already_sorted_out__main__scenarios.py
+++ b/removealreadysortedout/tests/unit/test_remove_already_sorted_out__main__scenarios.py
@@ -1,0 +1,53 @@
+"""
+Unit tests for remove_already_sorted_out.py.
+"""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "removealreadysortedout"
+sys.path.insert(0, str(package_root))
+
+import remove_already_sorted_out as ras
+
+
+def make_args(tmp_path, **overrides):
+    defaults = dict(
+        unsorted_folder=str(tmp_path / "unsorted"),
+        target_folder=str(tmp_path / "target"),
+        log_dir=str(tmp_path / "logs"),
+        overwrite=False,
+        debug=False,
+        index_prefix="PICT",
+        index_width=4,
+        index_max=10,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def test_parse_arguments__defaults(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["remove_already_sorted_out.py"])
+    args = ras.parse_arguments()
+    assert args.unsorted_folder
+
+
+def test_main__calls_operations(monkeypatch, tmp_path):
+    args = make_args(tmp_path)
+    monkeypatch.setattr(ras, "parse_arguments", lambda: args)
+    monkeypatch.setattr(ras, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(ras, "get_log_filename", lambda _p: "log.txt")
+    monkeypatch.setattr(ras, "setup_logging", lambda **_k: None)
+
+    monkeypatch.setattr(ras, "remove_desktop_ini", lambda *_a, **_k: None)
+    monkeypatch.setattr(ras, "unify_duplicate_files", lambda *_a, **_k: None)
+    monkeypatch.setattr(ras, "replace_in_filenames", lambda *_a, **_k: None)
+    monkeypatch.setattr(ras, "normalize_indexed_filenames", lambda *_a, **_k: None)
+    monkeypatch.setattr(ras, "list_files", lambda *_a, **_k: [])
+    monkeypatch.setattr(ras, "get_target_files_map", lambda *_a, **_k: {})
+    monkeypatch.setattr(ras, "find_duplicates", lambda *_a, **_k: {})
+    monkeypatch.setattr(ras, "handle_duplicate", lambda *_a, **_k: None)
+
+    ras.main()

--- a/removealreadysortedout/tests/unit/test_removealreadysortedout_constants__sanity.py
+++ b/removealreadysortedout/tests/unit/test_removealreadysortedout_constants__sanity.py
@@ -1,0 +1,18 @@
+"""
+Unit tests for removealreadysortedoutlib/constants.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "removealreadysortedout"
+sys.path.insert(0, str(package_root))
+
+from removealreadysortedoutlib import constants
+
+
+def test_constants__types():
+    assert isinstance(constants.DEFAULT_UNSORTED_FOLDER, str)
+    assert isinstance(constants.DEFAULT_TARGET_FOLDER, str)
+    assert isinstance(constants.DEFAULT_LOG_DIR, str)

--- a/removealreadysortedout/tests/unit/test_shared_csv_sanitizer__scenarios.py
+++ b/removealreadysortedout/tests/unit/test_shared_csv_sanitizer__scenarios.py
@@ -1,0 +1,21 @@
+"""
+Unit tests for removealreadysortedout/shared/csv_sanitizer.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "removealreadysortedout"
+sys.path.insert(0, str(package_root))
+
+from shared.csv_sanitizer import sanitize_field, is_dangerous
+
+
+def test_sanitize_field__dangerous_prefix():
+    assert sanitize_field("=1+1") == "'=1+1"
+
+
+def test_is_dangerous__safe_and_unsafe():
+    assert is_dangerous("=1+1") is True
+    assert is_dangerous("safe") is False

--- a/removealreadysortedout/tests/unit/test_shared_exif_downloader__scenarios.py
+++ b/removealreadysortedout/tests/unit/test_shared_exif_downloader__scenarios.py
@@ -1,0 +1,29 @@
+"""
+Unit tests for removealreadysortedout/shared/exif_downloader.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "removealreadysortedout"
+sys.path.insert(0, str(package_root))
+
+import shared.exif_downloader as exif_downloader
+
+
+def test_ensure_exiftool__missing(monkeypatch):
+    monkeypatch.setattr(exif_downloader.os.path, "exists", lambda _p: False)
+    try:
+        exif_downloader.ensure_exiftool()
+    except FileNotFoundError as exc:
+        assert "ExifTool not found" in str(exc)
+    else:
+        raise AssertionError("Expected FileNotFoundError")
+
+
+def test_ensure_exiftool__exists(monkeypatch):
+    monkeypatch.setattr(exif_downloader.os.path, "exists", lambda _p: True)
+    assert exif_downloader.ensure_exiftool() == exif_downloader.EXIFTOOL_PATH

--- a/removealreadysortedout/tests/unit/test_shared_exif_handler__scenarios.py
+++ b/removealreadysortedout/tests/unit/test_shared_exif_handler__scenarios.py
@@ -1,0 +1,49 @@
+"""
+Unit tests for removealreadysortedout/shared/exif_handler.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+from pathlib import Path
+from subprocess import CalledProcessError
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "removealreadysortedout"
+sys.path.insert(0, str(package_root))
+
+import shared.exif_handler as exif_handler
+
+
+def test_extract_exif_dates__no_data(monkeypatch):
+    monkeypatch.setattr(exif_handler, "ensure_exiftool", lambda *_a, **_k: "tool")
+    monkeypatch.setattr(exif_handler.subprocess, "run", lambda *_a, **_k: type("R", (), {"stdout": "[]"})())
+    assert exif_handler.extract_exif_dates("C:/file.jpg") == []
+
+
+def test_extract_exif_dates__returns_dates(monkeypatch):
+    monkeypatch.setattr(exif_handler, "ensure_exiftool", lambda *_a, **_k: "tool")
+    payload = '[{"CreateDate": "2024:01:02 10:11:12"}]'
+    monkeypatch.setattr(exif_handler.subprocess, "run", lambda *_a, **_k: type("R", (), {"stdout": payload})())
+    dates = exif_handler.extract_exif_dates("C:/file.jpg")
+    assert isinstance(dates[0], datetime)
+
+
+def test_update_exif_metadata__raises(monkeypatch):
+    monkeypatch.setattr(exif_handler, "ensure_exiftool", lambda *_a, **_k: "tool")
+    monkeypatch.setattr(exif_handler.subprocess, "run", lambda *_a, **_k: (_ for _ in ()).throw(CalledProcessError(1, "cmd")))
+    try:
+        exif_handler.update_exif_metadata("C:/file.jpg", {"Title": "x"})
+    except CalledProcessError:
+        assert True
+    else:
+        raise AssertionError("Expected CalledProcessError")
+
+
+def test_get_best_creation_date__fallback(monkeypatch):
+    monkeypatch.setattr(exif_handler, "extract_exif_dates", lambda *_a, **_k: [])
+    monkeypatch.setattr(exif_handler.os.path, "getctime", lambda _p: 1)
+    monkeypatch.setattr(exif_handler.os.path, "getmtime", lambda _p: 2)
+    result = exif_handler.get_best_creation_date("C:/file.jpg")
+    assert result is not None

--- a/removealreadysortedout/tests/unit/test_shared_file_operations__scenarios.py
+++ b/removealreadysortedout/tests/unit/test_shared_file_operations__scenarios.py
@@ -1,0 +1,29 @@
+"""
+Unit tests for removealreadysortedout/shared/file_operations.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "removealreadysortedout"
+sys.path.insert(0, str(package_root))
+
+import shared.file_operations as file_operations
+
+
+def test_list_files__non_recursive(tmp_path):
+    (tmp_path / "a.txt").write_text("a", encoding="utf-8")
+    (tmp_path / "b.log").write_text("b", encoding="utf-8")
+
+    files = file_operations.list_files(str(tmp_path), pattern="\\.txt$", recursive=False)
+    assert any(path.endswith("a.txt") for path in files)
+    assert all("b.log" not in path for path in files)
+
+
+def test_ensure_directory__creates(tmp_path):
+    target = tmp_path / "nested"
+    file_operations.ensure_directory(str(target))
+    assert target.exists()

--- a/removealreadysortedout/tests/unit/test_shared_hash_utils__scenarios.py
+++ b/removealreadysortedout/tests/unit/test_shared_hash_utils__scenarios.py
@@ -1,0 +1,33 @@
+"""
+Unit tests for removealreadysortedout/shared/hash_utils.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "removealreadysortedout"
+sys.path.insert(0, str(package_root))
+
+import shared.hash_utils as hash_utils
+
+
+def test_compute_file_hash__md5(tmp_path):
+    file_path = tmp_path / "data.txt"
+    file_path.write_text("abc", encoding="utf-8")
+
+    result = hash_utils.compute_file_hash(str(file_path), method="md5")
+    assert len(result) == 32
+
+
+def test_compute_file_hash__xxhash_fallback(monkeypatch, tmp_path):
+    file_path = tmp_path / "data.txt"
+    file_path.write_text("abc", encoding="utf-8")
+
+    monkeypatch.setattr(hash_utils, "XXHASH_AVAILABLE", False)
+    hash_utils._xxhash_warning_logged = False
+
+    result = hash_utils.compute_file_hash(str(file_path), method="xxhash64")
+    assert len(result) == 32

--- a/removealreadysortedout/tests/unit/test_shared_logging_config__scenarios.py
+++ b/removealreadysortedout/tests/unit/test_shared_logging_config__scenarios.py
@@ -1,0 +1,37 @@
+"""
+Unit tests for removealreadysortedout/shared/logging_config.py.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "removealreadysortedout"
+sys.path.insert(0, str(package_root))
+
+import shared.logging_config as logging_config
+
+
+def test_setup_logging__configures_handlers(monkeypatch):
+    fake_json = io.StringIO('{"DEBUG":"white","INFO":"green","WARNING":"yellow","ERROR":"red","CRITICAL":"red"}')
+    monkeypatch.setattr(logging_config, "open", lambda *_a, **_k: fake_json)
+
+    class DummyFormatter:
+        def __init__(self, *_a, **_k):
+            return None
+
+    class DummyHandler:
+        def __init__(self, *_a, **_k):
+            self.formatter = None
+
+        def setFormatter(self, formatter):
+            self.formatter = formatter
+
+    monkeypatch.setattr(logging_config.colorlog, "ColoredFormatter", DummyFormatter)
+    monkeypatch.setattr(logging_config.logging, "StreamHandler", lambda: DummyHandler())
+    monkeypatch.setattr(logging_config.logging, "FileHandler", lambda *_a, **_k: DummyHandler())
+
+    logging_config.setup_logging(debug=False, log_file="log.txt")

--- a/removealreadysortedout/tests/unit/test_shared_modules__scenarios.py
+++ b/removealreadysortedout/tests/unit/test_shared_modules__scenarios.py
@@ -1,0 +1,44 @@
+"""
+Unit tests for removealreadysortedout/shared modules.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "removealreadysortedout"
+sys.path.insert(0, str(package_root))
+
+import shared.hash_utils as hash_utils
+import shared.logging_config as logging_config
+import shared.utils as utils
+
+
+def test_hash_utils__md5(tmp_path):
+    data_file = tmp_path / "data.bin"
+    data_file.write_bytes(b"abc")
+    assert len(hash_utils.compute_file_hash(str(data_file), method="md5")) == 32
+
+
+def test_logging_config__missing_config_raises(monkeypatch):
+    monkeypatch.setattr(logging_config, "open", lambda *_a, **_k: (_ for _ in ()).throw(OSError("missing")))
+    with pytest.raises(Exception):
+        logging_config.setup_logging()
+
+
+def test_utils__get_log_filename(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["C:/tools/run_me.py"])
+
+    class DummyDateTime:
+        @classmethod
+        def now(cls):
+            class Dummy:
+                def strftime(self, _fmt):
+                    return "2020-01-01_12-00-00"
+
+            return Dummy()
+
+    monkeypatch.setattr(utils, "datetime", DummyDateTime)
+    assert utils.get_log_filename("C:/logs").endswith("run_me_Log_2020-01-01_12-00-00.log")

--- a/removealreadysortedout/tests/unit/test_shared_name_utils__scenarios.py
+++ b/removealreadysortedout/tests/unit/test_shared_name_utils__scenarios.py
@@ -1,0 +1,36 @@
+"""
+Unit tests for removealreadysortedout/shared/name_utils.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "removealreadysortedout"
+sys.path.insert(0, str(package_root))
+
+import shared.name_utils as name_utils
+
+
+def test_extract_numeric_suffix():
+    assert name_utils.extract_numeric_suffix("PICT0012.jpg") == 12
+    assert name_utils.extract_numeric_suffix("NOPE.jpg") is None
+
+
+def test_generate_indexed_filename():
+    assert name_utils.generate_indexed_filename(3, ".jpg") == "PICT0003.jpg"
+
+
+def test_generate_indexed_filename__invalid():
+    try:
+        name_utils.generate_indexed_filename(0, ".jpg")
+    except ValueError as exc:
+        assert "must be positive" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError")
+
+
+def test_find_next_available_number():
+    assert name_utils.find_next_available_number({1, 2, 3}, max_number=5) == 4

--- a/removealreadysortedout/tests/unit/test_shared_utils__scenarios.py
+++ b/removealreadysortedout/tests/unit/test_shared_utils__scenarios.py
@@ -1,0 +1,36 @@
+"""
+Unit tests for removealreadysortedout/shared/utils.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "removealreadysortedout"
+sys.path.insert(0, str(package_root))
+
+import shared.utils as utils
+
+
+def test_get_script_name__uses_argv(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["C:/tools/run_me.py"])
+    assert utils.get_script_name() == "run_me"
+
+
+def test_get_log_filename__formats(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["C:/tools/run_me.py"])
+
+    class DummyDateTime:
+        @classmethod
+        def now(cls):
+            class Dummy:
+                def strftime(self, _fmt):
+                    return "2020-01-01_12-00-00"
+
+            return Dummy()
+
+    monkeypatch.setattr(utils, "datetime", DummyDateTime)
+    result = utils.get_log_filename("C:/logs")
+    assert result.endswith("run_me_Log_2020-01-01_12-00-00.log")

--- a/sortunsortedmedia/tests/integration/test_main_pipeline__orders_categories.py
+++ b/sortunsortedmedia/tests/integration/test_main_pipeline__orders_categories.py
@@ -1,0 +1,47 @@
+"""
+Integration tests for sortunsortedmedia main category ordering.
+"""
+
+import types
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "sortunsortedmedia"
+sys.path.insert(0, str(package_root))
+
+import sortunsortedmedia
+
+
+def test_main_processes_categories_in_order(monkeypatch):
+    args = types.SimpleNamespace(
+        unsorted_folder="X:/unsorted",
+        target_folder="X:/target",
+        interval=0,
+        max_parallel=1,
+        debug=False,
+    )
+
+    unmatched = {
+        "jpg_files": ["a.jpg"],
+        "other_images": ["b.png"],
+        "videos": [],
+        "edited_images": ["c.jpg"],
+        "edited_videos": ["d.mp4"],
+    }
+
+    calls = []
+
+    monkeypatch.setattr(sortunsortedmedia, "parse_arguments", lambda: args)
+    monkeypatch.setattr(sortunsortedmedia, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(sortunsortedmedia, "get_log_filename", lambda _p: "log.txt")
+    monkeypatch.setattr(sortunsortedmedia, "setup_logging", lambda **_k: None)
+    monkeypatch.setattr(sortunsortedmedia, "find_unmatched_media", lambda *_a, **_k: unmatched)
+
+    def fake_process(files, *_a, **_k):
+        calls.append(list(files))
+
+    monkeypatch.setattr(sortunsortedmedia, "process_unmatched_files", fake_process)
+
+    sortunsortedmedia.main()
+    assert calls == [["a.jpg"], ["b.png"], ["c.jpg"], ["d.mp4"]]

--- a/sortunsortedmedia/tests/performance/test_detect_camera_from_filename__bulk.py
+++ b/sortunsortedmedia/tests/performance/test_detect_camera_from_filename__bulk.py
@@ -1,0 +1,18 @@
+"""
+Performance-oriented tests for camera detection.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "sortunsortedmedia"
+sys.path.insert(0, str(package_root))
+
+from sortunsortedmedialib.media_classifier import detect_camera_from_filename
+
+
+def test_detect_camera_from_filename_bulk():
+    filenames = [f"DSC_{i:04d}" for i in range(500)]
+    results = [detect_camera_from_filename(name) for name in filenames]
+    assert len(results) == 500

--- a/sortunsortedmedia/tests/security/test_main__skips_when_empty.py
+++ b/sortunsortedmedia/tests/security/test_main__skips_when_empty.py
@@ -1,0 +1,47 @@
+"""
+Security-focused tests for no-op when there are no unmatched files.
+"""
+
+import types
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "sortunsortedmedia"
+sys.path.insert(0, str(package_root))
+
+import sortunsortedmedia
+
+
+def test_main_skips_processing_when_empty(monkeypatch):
+    args = types.SimpleNamespace(
+        unsorted_folder="X:/unsorted",
+        target_folder="X:/target",
+        interval=0,
+        max_parallel=1,
+        debug=False,
+    )
+
+    empty = {
+        "jpg_files": [],
+        "other_images": [],
+        "videos": [],
+        "edited_images": [],
+        "edited_videos": [],
+    }
+
+    called = {"process": False}
+
+    monkeypatch.setattr(sortunsortedmedia, "parse_arguments", lambda: args)
+    monkeypatch.setattr(sortunsortedmedia, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(sortunsortedmedia, "get_log_filename", lambda _p: "log.txt")
+    monkeypatch.setattr(sortunsortedmedia, "setup_logging", lambda **_k: None)
+    monkeypatch.setattr(sortunsortedmedia, "find_unmatched_media", lambda *_a, **_k: empty)
+    monkeypatch.setattr(
+        sortunsortedmedia,
+        "process_unmatched_files",
+        lambda *_a, **_k: called.__setitem__("process", True),
+    )
+
+    sortunsortedmedia.main()
+    assert called["process"] is False

--- a/sortunsortedmedia/tests/unit/test_constants__sanity.py
+++ b/sortunsortedmedia/tests/unit/test_constants__sanity.py
@@ -1,0 +1,23 @@
+"""
+Sanity tests for sortunsortedmedialib/constants.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "sortunsortedmedia"
+sys.path.insert(0, str(package_root))
+
+from sortunsortedmedialib import constants
+
+
+def test_default_paths_present():
+    assert constants.DEFAULT_UNSORTED_FOLDER
+    assert constants.DEFAULT_TARGET_FOLDER
+
+
+def test_extension_types_contains_jpg():
+    assert constants.EXTENSION_TYPES["jpg"] == "Foto"

--- a/sortunsortedmedia/tests/unit/test_interactive__scenarios.py
+++ b/sortunsortedmedia/tests/unit/test_interactive__scenarios.py
@@ -1,0 +1,18 @@
+"""
+Unit tests for sortunsortedmedialib/interactive.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "sortunsortedmedia"
+sys.path.insert(0, str(package_root))
+
+from sortunsortedmedialib import interactive
+
+
+def test_ask_for_category_returns_default():
+    assert interactive.ask_for_category("C:/file.jpg") == "Ostatn¡"

--- a/sortunsortedmedia/tests/unit/test_media_classifier__scenarios.py
+++ b/sortunsortedmedia/tests/unit/test_media_classifier__scenarios.py
@@ -1,0 +1,26 @@
+"""
+Unit tests for sortunsortedmedialib/media_classifier.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "sortunsortedmedia"
+sys.path.insert(0, str(package_root))
+
+import sortunsortedmedialib.media_classifier as media_classifier
+
+
+def test_detect_camera_from_filename():
+    assert media_classifier.detect_camera_from_filename("DSC00001") == "Sony CyberShot W810"
+
+
+def test_classify_media_file(monkeypatch):
+    monkeypatch.setattr(media_classifier, "is_edited_file", lambda _f: False)
+    monkeypatch.setattr(media_classifier, "combine_regex_and_exif_detection", lambda _p, _c: "Camera")
+    media_type, camera, is_edited, edit_type = media_classifier.classify_media_file("C:/file.jpg")
+    assert camera == "Camera"
+    assert is_edited is False

--- a/sortunsortedmedia/tests/unit/test_media_helper__scenarios.py
+++ b/sortunsortedmedia/tests/unit/test_media_helper__scenarios.py
@@ -1,0 +1,43 @@
+"""
+Unit tests for sortunsortedmedialib/media_helper.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from subprocess import CalledProcessError
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "sortunsortedmedia"
+sys.path.insert(0, str(package_root))
+
+import sortunsortedmedialib.media_helper as media_helper
+
+
+def test_open_media_file__missing(monkeypatch):
+    monkeypatch.setattr(media_helper.os.path, "exists", lambda _p: False)
+    assert media_helper.open_media_file("C:/missing.jpg") is False
+
+
+def test_is_media_file_and_video():
+    assert media_helper.is_media_file("file.jpg") is True
+    assert media_helper.is_video_file("file.mp4") is True
+    assert media_helper.is_jpg_file("file.jpeg") is True
+
+
+def test_is_edited_file():
+    assert media_helper.is_edited_file("IMG_bw.jpg") is True
+
+
+def test_find_unmatched_media(monkeypatch):
+    monkeypatch.setattr(media_helper, "list_files", lambda _p, recursive=True: ["C:/a.jpg", "C:/b.mp4"])
+    monkeypatch.setattr(media_helper, "is_media_file", lambda _p: True)
+    monkeypatch.setattr(media_helper.os.path, "basename", lambda p: p.split("/")[-1])
+    result = media_helper.find_unmatched_media("unsorted", "target")
+    assert "jpg_files" in result
+
+
+def test_open_appropriate_editor__unsupported(monkeypatch):
+    monkeypatch.setattr(media_helper.os.path, "exists", lambda _p: False)
+    assert media_helper.open_appropriate_editor("C:/file.unknown") is False

--- a/sortunsortedmedia/tests/unit/test_path_builder__scenarios.py
+++ b/sortunsortedmedia/tests/unit/test_path_builder__scenarios.py
@@ -1,0 +1,35 @@
+"""
+Unit tests for sortunsortedmedialib/path_builder.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "sortunsortedmedia"
+sys.path.insert(0, str(package_root))
+
+from sortunsortedmedialib import path_builder
+
+
+def test_build_target_path():
+    date = datetime(2024, 1, 2)
+    path = path_builder.build_target_path("C:/base", "Foto", "jpg", "Cat", date, "Camera")
+    assert "Foto" in path
+    assert "2024" in path
+
+
+def test_build_edited_target_path():
+    date = datetime(2024, 1, 2)
+    path = path_builder.build_edited_target_path("C:/base", "Foto", "jpg", "Cat", date, "Camera")
+    assert "Upraven" in path
+
+
+def test_ensure_unique_path(tmp_path):
+    target = tmp_path / "file.txt"
+    target.write_text("x", encoding="utf-8")
+    unique = path_builder.ensure_unique_path(str(target))
+    assert unique != str(target)

--- a/sortunsortedmedia/tests/unit/test_shared_csv_sanitizer__scenarios.py
+++ b/sortunsortedmedia/tests/unit/test_shared_csv_sanitizer__scenarios.py
@@ -1,0 +1,21 @@
+"""
+Unit tests for sortunsortedmedia/shared/csv_sanitizer.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "sortunsortedmedia"
+sys.path.insert(0, str(package_root))
+
+from shared.csv_sanitizer import sanitize_field, is_dangerous
+
+
+def test_sanitize_field__dangerous_prefix():
+    assert sanitize_field("=1+1") == "'=1+1"
+
+
+def test_is_dangerous__safe_and_unsafe():
+    assert is_dangerous("=1+1") is True
+    assert is_dangerous("safe") is False

--- a/sortunsortedmedia/tests/unit/test_shared_exif_downloader__scenarios.py
+++ b/sortunsortedmedia/tests/unit/test_shared_exif_downloader__scenarios.py
@@ -1,0 +1,29 @@
+"""
+Unit tests for sortunsortedmedia/shared/exif_downloader.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "sortunsortedmedia"
+sys.path.insert(0, str(package_root))
+
+import shared.exif_downloader as exif_downloader
+
+
+def test_ensure_exiftool__missing(monkeypatch):
+    monkeypatch.setattr(exif_downloader.os.path, "exists", lambda _p: False)
+    try:
+        exif_downloader.ensure_exiftool()
+    except FileNotFoundError as exc:
+        assert "ExifTool not found" in str(exc)
+    else:
+        raise AssertionError("Expected FileNotFoundError")
+
+
+def test_ensure_exiftool__exists(monkeypatch):
+    monkeypatch.setattr(exif_downloader.os.path, "exists", lambda _p: True)
+    assert exif_downloader.ensure_exiftool() == exif_downloader.EXIFTOOL_PATH

--- a/sortunsortedmedia/tests/unit/test_shared_exif_handler__scenarios.py
+++ b/sortunsortedmedia/tests/unit/test_shared_exif_handler__scenarios.py
@@ -1,0 +1,49 @@
+"""
+Unit tests for sortunsortedmedia/shared/exif_handler.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+from pathlib import Path
+from subprocess import CalledProcessError
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "sortunsortedmedia"
+sys.path.insert(0, str(package_root))
+
+import shared.exif_handler as exif_handler
+
+
+def test_extract_exif_dates__no_data(monkeypatch):
+    monkeypatch.setattr(exif_handler, "ensure_exiftool", lambda *_a, **_k: "tool")
+    monkeypatch.setattr(exif_handler.subprocess, "run", lambda *_a, **_k: type("R", (), {"stdout": "[]"})())
+    assert exif_handler.extract_exif_dates("C:/file.jpg") == []
+
+
+def test_extract_exif_dates__returns_dates(monkeypatch):
+    monkeypatch.setattr(exif_handler, "ensure_exiftool", lambda *_a, **_k: "tool")
+    payload = '[{"CreateDate": "2024:01:02 10:11:12"}]'
+    monkeypatch.setattr(exif_handler.subprocess, "run", lambda *_a, **_k: type("R", (), {"stdout": payload})())
+    dates = exif_handler.extract_exif_dates("C:/file.jpg")
+    assert isinstance(dates[0], datetime)
+
+
+def test_update_exif_metadata__raises(monkeypatch):
+    monkeypatch.setattr(exif_handler, "ensure_exiftool", lambda *_a, **_k: "tool")
+    monkeypatch.setattr(exif_handler.subprocess, "run", lambda *_a, **_k: (_ for _ in ()).throw(CalledProcessError(1, "cmd")))
+    try:
+        exif_handler.update_exif_metadata("C:/file.jpg", {"Title": "x"})
+    except CalledProcessError:
+        assert True
+    else:
+        raise AssertionError("Expected CalledProcessError")
+
+
+def test_get_best_creation_date__fallback(monkeypatch):
+    monkeypatch.setattr(exif_handler, "extract_exif_dates", lambda *_a, **_k: [])
+    monkeypatch.setattr(exif_handler.os.path, "getctime", lambda _p: 1)
+    monkeypatch.setattr(exif_handler.os.path, "getmtime", lambda _p: 2)
+    result = exif_handler.get_best_creation_date("C:/file.jpg")
+    assert result is not None

--- a/sortunsortedmedia/tests/unit/test_shared_file_operations__scenarios.py
+++ b/sortunsortedmedia/tests/unit/test_shared_file_operations__scenarios.py
@@ -1,0 +1,29 @@
+"""
+Unit tests for sortunsortedmedia/shared/file_operations.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "sortunsortedmedia"
+sys.path.insert(0, str(package_root))
+
+import shared.file_operations as file_operations
+
+
+def test_list_files__non_recursive(tmp_path):
+    (tmp_path / "a.txt").write_text("a", encoding="utf-8")
+    (tmp_path / "b.log").write_text("b", encoding="utf-8")
+
+    files = file_operations.list_files(str(tmp_path), pattern="\\.txt$", recursive=False)
+    assert any(path.endswith("a.txt") for path in files)
+    assert all("b.log" not in path for path in files)
+
+
+def test_ensure_directory__creates(tmp_path):
+    target = tmp_path / "nested"
+    file_operations.ensure_directory(str(target))
+    assert target.exists()

--- a/sortunsortedmedia/tests/unit/test_shared_hash_utils__scenarios.py
+++ b/sortunsortedmedia/tests/unit/test_shared_hash_utils__scenarios.py
@@ -1,0 +1,33 @@
+"""
+Unit tests for sortunsortedmedia/shared/hash_utils.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "sortunsortedmedia"
+sys.path.insert(0, str(package_root))
+
+import shared.hash_utils as hash_utils
+
+
+def test_compute_file_hash__md5(tmp_path):
+    file_path = tmp_path / "data.txt"
+    file_path.write_text("abc", encoding="utf-8")
+
+    result = hash_utils.compute_file_hash(str(file_path), method="md5")
+    assert len(result) == 32
+
+
+def test_compute_file_hash__xxhash_fallback(monkeypatch, tmp_path):
+    file_path = tmp_path / "data.txt"
+    file_path.write_text("abc", encoding="utf-8")
+
+    monkeypatch.setattr(hash_utils, "XXHASH_AVAILABLE", False)
+    hash_utils._xxhash_warning_logged = False
+
+    result = hash_utils.compute_file_hash(str(file_path), method="xxhash64")
+    assert len(result) == 32

--- a/sortunsortedmedia/tests/unit/test_shared_logging_config__scenarios.py
+++ b/sortunsortedmedia/tests/unit/test_shared_logging_config__scenarios.py
@@ -1,0 +1,37 @@
+"""
+Unit tests for sortunsortedmedia/shared/logging_config.py.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "sortunsortedmedia"
+sys.path.insert(0, str(package_root))
+
+import shared.logging_config as logging_config
+
+
+def test_setup_logging__configures_handlers(monkeypatch):
+    fake_json = io.StringIO('{"DEBUG":"white","INFO":"green","WARNING":"yellow","ERROR":"red","CRITICAL":"red"}')
+    monkeypatch.setattr(logging_config, "open", lambda *_a, **_k: fake_json)
+
+    class DummyFormatter:
+        def __init__(self, *_a, **_k):
+            return None
+
+    class DummyHandler:
+        def __init__(self, *_a, **_k):
+            self.formatter = None
+
+        def setFormatter(self, formatter):
+            self.formatter = formatter
+
+    monkeypatch.setattr(logging_config.colorlog, "ColoredFormatter", DummyFormatter)
+    monkeypatch.setattr(logging_config.logging, "StreamHandler", lambda: DummyHandler())
+    monkeypatch.setattr(logging_config.logging, "FileHandler", lambda *_a, **_k: DummyHandler())
+
+    logging_config.setup_logging(debug=False, log_file="log.txt")

--- a/sortunsortedmedia/tests/unit/test_shared_modules__scenarios.py
+++ b/sortunsortedmedia/tests/unit/test_shared_modules__scenarios.py
@@ -1,0 +1,44 @@
+"""
+Unit tests for sortunsortedmedia/shared modules.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "sortunsortedmedia"
+sys.path.insert(0, str(package_root))
+
+import shared.hash_utils as hash_utils
+import shared.logging_config as logging_config
+import shared.utils as utils
+
+
+def test_hash_utils__md5(tmp_path):
+    data_file = tmp_path / "data.bin"
+    data_file.write_bytes(b"abc")
+    assert len(hash_utils.compute_file_hash(str(data_file), method="md5")) == 32
+
+
+def test_logging_config__missing_config_raises(monkeypatch):
+    monkeypatch.setattr(logging_config, "open", lambda *_a, **_k: (_ for _ in ()).throw(OSError("missing")))
+    with pytest.raises(Exception):
+        logging_config.setup_logging()
+
+
+def test_utils__get_log_filename(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["C:/tools/run_me.py"])
+
+    class DummyDateTime:
+        @classmethod
+        def now(cls):
+            class Dummy:
+                def strftime(self, _fmt):
+                    return "2020-01-01_12-00-00"
+
+            return Dummy()
+
+    monkeypatch.setattr(utils, "datetime", DummyDateTime)
+    assert utils.get_log_filename("C:/logs").endswith("run_me_Log_2020-01-01_12-00-00.log")

--- a/sortunsortedmedia/tests/unit/test_shared_utils__scenarios.py
+++ b/sortunsortedmedia/tests/unit/test_shared_utils__scenarios.py
@@ -1,0 +1,36 @@
+"""
+Unit tests for sortunsortedmedia/shared/utils.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "sortunsortedmedia"
+sys.path.insert(0, str(package_root))
+
+import shared.utils as utils
+
+
+def test_get_script_name__uses_argv(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["C:/tools/run_me.py"])
+    assert utils.get_script_name() == "run_me"
+
+
+def test_get_log_filename__formats(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["C:/tools/run_me.py"])
+
+    class DummyDateTime:
+        @classmethod
+        def now(cls):
+            class Dummy:
+                def strftime(self, _fmt):
+                    return "2020-01-01_12-00-00"
+
+            return Dummy()
+
+    monkeypatch.setattr(utils, "datetime", DummyDateTime)
+    result = utils.get_log_filename("C:/logs")
+    assert result.endswith("run_me_Log_2020-01-01_12-00-00.log")

--- a/sortunsortedmedia/tests/unit/test_sortunsortedmedia__main__scenarios.py
+++ b/sortunsortedmedia/tests/unit/test_sortunsortedmedia__main__scenarios.py
@@ -1,0 +1,44 @@
+"""
+Unit tests for sortunsortedmedia.py.
+"""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "sortunsortedmedia"
+sys.path.insert(0, str(package_root))
+
+import sortunsortedmedia as sumedia
+
+
+def make_args(tmp_path, **overrides):
+    defaults = dict(
+        unsorted_folder=str(tmp_path / "unsorted"),
+        target_folder=str(tmp_path / "target"),
+        interval=0,
+        max_parallel=1,
+        debug=False,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def test_parse_arguments__defaults(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["sortunsortedmedia.py"])
+    args = sumedia.parse_arguments()
+    assert args.unsorted_folder
+
+
+def test_main__no_unmatched(monkeypatch, tmp_path):
+    args = make_args(tmp_path)
+    monkeypatch.setattr(sumedia, "parse_arguments", lambda: args)
+    monkeypatch.setattr(sumedia, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(sumedia, "get_log_filename", lambda _p: "log.txt")
+    monkeypatch.setattr(sumedia, "setup_logging", lambda **_k: None)
+    monkeypatch.setattr(sumedia, "find_unmatched_media", lambda *_a, **_k: {
+        "jpg_files": [], "other_images": [], "videos": [], "edited_images": [], "edited_videos": []
+    })
+
+    assert sumedia.main() is None

--- a/sortunsortedmedia/tests/unit/test_sortunsortedmediafile__import.py
+++ b/sortunsortedmedia/tests/unit/test_sortunsortedmediafile__import.py
@@ -1,0 +1,14 @@
+"""
+Import smoke test for sortunsortedmediafile.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "sortunsortedmedia"
+sys.path.insert(0, str(package_root))
+
+
+def test_import_sortunsortedmediafile():
+    import sortunsortedmediafile  # noqa: F401

--- a/sortunsortedmedia/tests/unit/test_sortunsortedmedialib_imports__scenarios.py
+++ b/sortunsortedmedia/tests/unit/test_sortunsortedmedialib_imports__scenarios.py
@@ -1,0 +1,38 @@
+"""
+Import smoke tests for sortunsortedmedialib modules not yet covered.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "sortunsortedmedia"
+sys.path.insert(0, str(package_root))
+
+
+def test_import_constants():
+    import sortunsortedmedialib.constants  # noqa: F401
+
+
+def test_import_matching_engine():
+    import sortunsortedmedialib.matching_engine  # noqa: F401
+
+
+def test_import_media_classifier():
+    import sortunsortedmedialib.media_classifier  # noqa: F401
+
+
+def test_import_media_helper():
+    import sortunsortedmedialib.media_helper  # noqa: F401
+
+
+def test_import_media_viewer():
+    import sortunsortedmedialib.media_viewer  # noqa: F401
+
+
+def test_import_path_builder():
+    import sortunsortedmedialib.path_builder  # noqa: F401
+
+
+def test_import_interactive():
+    import sortunsortedmedialib.interactive  # noqa: F401

--- a/tests/unit/test_fix_dates__scenarios.py
+++ b/tests/unit/test_fix_dates__scenarios.py
@@ -1,0 +1,30 @@
+"""
+Unit tests for fix_dates.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(project_root))
+
+import fix_dates
+
+
+def test_parse_date__already_formatted():
+    assert fix_dates.parse_date("01.01.2024") == "01.01.2024"
+
+
+def test_parse_date__iso_datetime():
+    assert fix_dates.parse_date("2024-01-15 10:11:12") == "15.01.2024"
+
+
+def test_parse_date__invalid_returns_original():
+    assert fix_dates.parse_date("not-a-date") == "not-a-date"
+
+
+def test_main__missing_file(monkeypatch):
+    monkeypatch.setattr(fix_dates.os.path, "exists", lambda _p: False)
+    assert fix_dates.main() == 1

--- a/tests/unit/test_user_config__scenarios.py
+++ b/tests/unit/test_user_config__scenarios.py
@@ -1,0 +1,59 @@
+"""
+Unit tests for shared/user_config.py.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(project_root))
+
+import shared.user_config as user_config
+
+
+def test_load_from_environment(monkeypatch):
+    monkeypatch.setenv("PHOTOBANK_USERNAME", "alice")
+    monkeypatch.setenv("PHOTOBANK_AUTHOR", "Alice")
+
+    config = user_config.UserConfig.__new__(user_config.UserConfig)
+    result = config._load_from_environment()
+    assert result["username"] == "alice"
+    assert result["author"] == "Alice"
+
+
+def test_load_from_file(monkeypatch, tmp_path):
+    config_path = tmp_path / "user.config.json"
+    config_path.write_text(json.dumps({"username": "bob", "author": "Bob"}), encoding="utf-8")
+
+    monkeypatch.setattr(user_config.Path, "home", lambda: tmp_path / "home")
+    monkeypatch.setattr(user_config.Path, "cwd", lambda: tmp_path)
+
+    config = user_config.UserConfig.__new__(user_config.UserConfig)
+    data = config._load_from_file()
+    assert data["username"] == "bob"
+    assert data["author"] == "Bob"
+
+
+def test_getters_and_defaults(monkeypatch):
+    config = user_config.UserConfig.__new__(user_config.UserConfig)
+    config._config = {}
+    monkeypatch.setenv("USERNAME", "system-user")
+
+    assert config.get_username() == "system-user"
+    assert config.get_author() == "Unknown Author"
+
+
+def test_is_configured():
+    config = user_config.UserConfig.__new__(user_config.UserConfig)
+    config._config = {"author": "Custom", "location": "X"}
+    assert config.is_configured() is True
+
+
+def test_get_copyright_notice():
+    config = user_config.UserConfig.__new__(user_config.UserConfig)
+    config._config = {"author": "Me"}
+    assert config.get_copyright_notice(2020) == "Me 2020"

--- a/updatemediadatabase/tests/integration/test_main_pipeline__phases.py
+++ b/updatemediadatabase/tests/integration/test_main_pipeline__phases.py
@@ -1,0 +1,61 @@
+"""
+Integration tests for updatemediadatabase main phase flow.
+"""
+
+import types
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "updatemediadatabase"
+sys.path.insert(0, str(package_root))
+
+import updatemediadatabase
+from updatemedialdatabaselib.constants import COLUMN_FILENAME
+
+
+def test_main_runs_all_phases(monkeypatch):
+    args = types.SimpleNamespace(
+        media_csv="X:/media.csv",
+        limits_csv="X:/limits.csv",
+        photo_dir="X:/photos",
+        video_dir="X:/videos",
+        edit_photo_dir="X:/edit_photos",
+        edit_video_dir="X:/edit_videos",
+        log_dir="X:/logs",
+        debug=False,
+    )
+
+    store = {"data": []}
+
+    def fake_load_csv(_path):
+        return list(store["data"])
+
+    def fake_save_csv_with_backup(data, _path):
+        store["data"] = list(data)
+
+    def fake_list_files(directory, recursive=True):
+        if directory.endswith("photos"):
+            return ["C:/photos/a.jpg", "C:/photos/b.png"]
+        if directory.endswith("videos"):
+            return ["C:/videos/c.mp4"]
+        return []
+
+    def fake_process_media_file(path, _db, _limits, _exiftool, _existing):
+        return {COLUMN_FILENAME: Path(path).name}
+
+    monkeypatch.setattr(updatemediadatabase, "parse_arguments", lambda: args)
+    monkeypatch.setattr(updatemediadatabase, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(updatemediadatabase, "get_log_filename", lambda _p: "log.txt")
+    monkeypatch.setattr(updatemediadatabase, "setup_logging", lambda **_k: None)
+    monkeypatch.setattr(updatemediadatabase, "ensure_exiftool", lambda: "exiftool")
+    monkeypatch.setattr(updatemediadatabase, "load_csv", fake_load_csv)
+    monkeypatch.setattr(updatemediadatabase, "save_csv_with_backup", fake_save_csv_with_backup)
+    monkeypatch.setattr(updatemediadatabase, "list_files", fake_list_files)
+    monkeypatch.setattr(updatemediadatabase, "process_media_file", fake_process_media_file)
+    monkeypatch.setattr(updatemediadatabase.os.path, "exists", lambda _p: True)
+
+    updatemediadatabase.main()
+
+    filenames = {row[COLUMN_FILENAME] for row in store["data"]}
+    assert filenames == {"a.jpg", "b.png", "c.mp4"}

--- a/updatemediadatabase/tests/performance/test_split_files_by_type__bulk.py
+++ b/updatemediadatabase/tests/performance/test_split_files_by_type__bulk.py
@@ -1,0 +1,20 @@
+"""
+Performance-oriented tests for file type splitting.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "updatemediadatabase"
+sys.path.insert(0, str(package_root))
+
+from updatemediadatabase import split_files_by_type
+
+
+def test_split_files_by_type_bulk():
+    files = [f"C:/media/file_{i}.jpg" for i in range(300)]
+    files += [f"C:/media/clip_{i}.mp4" for i in range(100)]
+    result = split_files_by_type(files)
+    assert len(result["jpg"]) == 300
+    assert len(result["videos"]) == 100

--- a/updatemediadatabase/tests/security/test_save_csv_with_backup__sanitizes.py
+++ b/updatemediadatabase/tests/security/test_save_csv_with_backup__sanitizes.py
@@ -1,0 +1,27 @@
+"""
+Security-focused tests for CSV injection sanitization in save_csv_with_backup.
+"""
+
+import csv
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "updatemediadatabase"
+sys.path.insert(0, str(package_root))
+
+from shared.file_operations import save_csv_with_backup
+
+
+def test_save_csv_with_backup_sanitizes_formula(tmp_path):
+    csv_path = tmp_path / "media.csv"
+    csv_path.write_text("col\nsafe\n", encoding="utf-8-sig")
+
+    records = [{"col": "=SUM(1,2)"}]
+    save_csv_with_backup(records, str(csv_path))
+
+    with open(csv_path, "r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.DictReader(handle)
+        rows = list(reader)
+
+    assert rows[0]["col"].startswith("'=")

--- a/updatemediadatabase/tests/unit/__init__.py
+++ b/updatemediadatabase/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests package for updatemediadatabase."""

--- a/updatemediadatabase/tests/unit/test_constants__sanity.py
+++ b/updatemediadatabase/tests/unit/test_constants__sanity.py
@@ -1,0 +1,24 @@
+"""
+Sanity tests for updatemedialdatabaselib/constants.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "updatemediadatabase"
+sys.path.insert(0, str(package_root))
+
+from updatemedialdatabaselib import constants
+
+
+def test_default_paths_present():
+    assert constants.DEFAULT_MEDIA_CSV_PATH
+    assert constants.DEFAULT_LIMITS_CSV_PATH
+
+
+def test_numbering_limits():
+    assert constants.MIN_NUMBER_WIDTH <= constants.DEFAULT_NUMBER_WIDTH <= constants.MAX_NUMBER_WIDTH
+    assert constants.MAX_NUMBER == 999999

--- a/updatemediadatabase/tests/unit/test_edit_utils__scenarios.py
+++ b/updatemediadatabase/tests/unit/test_edit_utils__scenarios.py
@@ -1,0 +1,43 @@
+"""
+Unit tests for updatemedialdatabaselib/edit_utils.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "updatemediadatabase"
+sys.path.insert(0, str(package_root))
+
+from updatemedialdatabaselib import edit_utils
+
+
+def test_get_edit_type():
+    assert edit_utils.get_edit_type("IMG_0001_bw.jpg") == "bw"
+    assert edit_utils.get_edit_type("IMG_0001.jpg") is None
+
+
+def test_is_edited_file():
+    assert edit_utils.is_edited_file("IMG_0001_bw.jpg") is True
+    assert edit_utils.is_edited_file("IMG_0001.jpg") is False
+
+
+def test_get_original_filename():
+    assert edit_utils.get_original_filename("IMG_0001_bw.jpg") == "IMG_0001.jpg"
+
+
+def test_modify_description_for_edit():
+    result = edit_utils.modify_description_for_edit("Forest", "bw")
+    assert result.startswith("Black and white image")
+
+
+def test_modify_keywords_for_edit():
+    result = edit_utils.modify_keywords_for_edit("forest", "bw")
+    assert "black and white" in result
+
+
+def test_update_metadata_for_edit():
+    updated = edit_utils.update_metadata_for_edit({"Description": "Desc", "Keywords": "one"}, "bw")
+    assert "EditType" in updated

--- a/updatemediadatabase/tests/unit/test_exif_downloader__scenarios.py
+++ b/updatemediadatabase/tests/unit/test_exif_downloader__scenarios.py
@@ -1,0 +1,29 @@
+"""
+Unit tests for updatemedialdatabaselib/exif_downloader.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "updatemediadatabase"
+sys.path.insert(0, str(package_root))
+
+import updatemedialdatabaselib.exif_downloader as exif_downloader
+
+
+def test_ensure_exiftool__missing(monkeypatch):
+    monkeypatch.setattr(exif_downloader.os.path, "exists", lambda _p: False)
+    try:
+        exif_downloader.ensure_exiftool()
+    except FileNotFoundError as exc:
+        assert "ExifTool not found" in str(exc)
+    else:
+        raise AssertionError("Expected FileNotFoundError")
+
+
+def test_ensure_exiftool__exists(monkeypatch):
+    monkeypatch.setattr(exif_downloader.os.path, "exists", lambda _p: True)
+    assert exif_downloader.ensure_exiftool() == exif_downloader.EXIFTOOL_PATH

--- a/updatemediadatabase/tests/unit/test_exif_handler__scenarios.py
+++ b/updatemediadatabase/tests/unit/test_exif_handler__scenarios.py
@@ -1,0 +1,48 @@
+"""
+Unit tests for updatemedialdatabaselib/exif_handler.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from subprocess import CalledProcessError
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "updatemediadatabase"
+sys.path.insert(0, str(package_root))
+
+import updatemedialdatabaselib.exif_handler as exif_handler
+
+
+def test_update_exif_metadata__missing_file(monkeypatch):
+    monkeypatch.setattr(exif_handler.os.path, "exists", lambda _p: False)
+    assert exif_handler.update_exif_metadata("C:/missing.jpg", {}, "C:/exiftool") is False
+
+
+def test_update_exif_metadata__missing_tool(monkeypatch):
+    def fake_exists(path):
+        return path == "C:/file.jpg"
+
+    monkeypatch.setattr(exif_handler.os.path, "exists", fake_exists)
+    assert exif_handler.update_exif_metadata("C:/file.jpg", {}, "C:/exiftool") is False
+
+
+def test_update_exif_metadata__success(monkeypatch):
+    monkeypatch.setattr(exif_handler.os.path, "exists", lambda _p: True)
+
+    class DummyResult:
+        stdout = "1 image files updated"
+
+    monkeypatch.setattr(exif_handler.subprocess, "run", lambda *_a, **_k: DummyResult())
+    assert exif_handler.update_exif_metadata("C:/file.jpg", {"Title": "x"}, "C:/exiftool") is True
+
+
+def test_update_exif_metadata__subprocess_error(monkeypatch):
+    monkeypatch.setattr(exif_handler.os.path, "exists", lambda _p: True)
+
+    def fake_run(*_a, **_k):
+        raise CalledProcessError(1, "cmd", stderr="boom")
+
+    monkeypatch.setattr(exif_handler.subprocess, "run", fake_run)
+    assert exif_handler.update_exif_metadata("C:/file.jpg", {"Title": "x"}, "C:/exiftool") is False

--- a/updatemediadatabase/tests/unit/test_media_processor__scenarios.py
+++ b/updatemediadatabase/tests/unit/test_media_processor__scenarios.py
@@ -1,0 +1,69 @@
+"""
+Unit tests for updatemedialdatabaselib/media_processor.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "updatemediadatabase"
+sys.path.insert(0, str(package_root))
+
+import updatemedialdatabaselib.media_processor as media_processor
+
+
+def test_get_bank_status__valid():
+    assert media_processor.get_bank_status("Bank", True, {}) == "nezpracov no"
+
+
+def test_extract_category_from_path():
+    category = media_processor.extract_category_from_path("C:/a/b/c/d/file.jpg")
+    assert category == "a"
+
+
+def test_calculate_resolution_mpx():
+    assert media_processor.calculate_resolution_mpx(2000, 1000) == "2.0"
+
+
+def test_determine_media_type():
+    assert media_processor.determine_media_type("file.jpg", False) == media_processor.TYPE_PHOTO
+    assert media_processor.determine_media_type("file.mp4", True) == media_processor.TYPE_EDITED_VIDEO
+
+
+def test_is_file_in_database():
+    assert media_processor.is_file_in_database("C:/file.jpg", {"file.jpg"}) is True
+
+
+def test_create_database_record__fields():
+    metadata = {"Filename": "file.jpg", "Path": "C:/x/y/z/file.jpg", "Width": 100, "Height": 50}
+    record = media_processor.create_database_record(metadata, {"ShutterStock": True})
+    assert record[media_processor.COLUMN_FILENAME] == "file.jpg"
+
+
+def test_process_media_file__skips_existing(monkeypatch):
+    result = media_processor.process_media_file(
+        "C:/file.jpg",
+        database=[],
+        limits=[],
+        exiftool_path="C:/exiftool",
+        existing_filenames={"file.jpg"},
+    )
+    assert result is None
+
+
+def test_process_media_file__creates_record(monkeypatch):
+    monkeypatch.setattr(media_processor, "extract_metadata", lambda *_a, **_k: {"Filename": "file.jpg", "Path": "C:/file.jpg"})
+    monkeypatch.setattr(media_processor, "is_edited_file", lambda _f: False)
+    monkeypatch.setattr(media_processor, "validate_against_limits", lambda *_a, **_k: {"ShutterStock": True})
+    monkeypatch.setattr(media_processor, "create_database_record", lambda *_a, **_k: {"Soubor": "file.jpg"})
+
+    record = media_processor.process_media_file(
+        "C:/file.jpg",
+        database=[],
+        limits=[],
+        exiftool_path="C:/exiftool",
+        existing_filenames=set(),
+    )
+    assert record == {"Soubor": "file.jpg"}

--- a/updatemediadatabase/tests/unit/test_photo_analyzer__scenarios.py
+++ b/updatemediadatabase/tests/unit/test_photo_analyzer__scenarios.py
@@ -1,0 +1,72 @@
+"""
+Unit tests for updatemedialdatabaselib/photo_analyzer.py.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from subprocess import CalledProcessError
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "updatemediadatabase"
+sys.path.insert(0, str(package_root))
+
+import updatemedialdatabaselib.photo_analyzer as photo_analyzer
+
+
+def test_extract_metadata__missing_file(monkeypatch):
+    monkeypatch.setattr(photo_analyzer.os.path, "exists", lambda _p: False)
+    assert photo_analyzer.extract_metadata("C:/missing.jpg", "C:/exiftool") == {}
+
+
+def test_extract_metadata__missing_tool(monkeypatch):
+    def fake_exists(path):
+        return path == "C:/file.jpg"
+
+    monkeypatch.setattr(photo_analyzer.os.path, "exists", fake_exists)
+    assert photo_analyzer.extract_metadata("C:/file.jpg", "C:/exiftool") == {}
+
+
+def test_extract_metadata__exiftool_failure(monkeypatch):
+    monkeypatch.setattr(photo_analyzer.os.path, "exists", lambda _p: True)
+    monkeypatch.setattr(photo_analyzer.os.path, "getsize", lambda _p: 10)
+    monkeypatch.setattr(photo_analyzer.os.path, "getmtime", lambda _p: 0)
+
+    def fake_run(*_a, **_k):
+        raise CalledProcessError(1, "cmd", stderr="boom")
+
+    monkeypatch.setattr(photo_analyzer.subprocess, "run", fake_run)
+    metadata = photo_analyzer.extract_metadata("C:/file.jpg", "C:/exiftool")
+    assert metadata["Filename"] == "file.jpg"
+
+
+def test_extract_metadata__parses_json(monkeypatch):
+    monkeypatch.setattr(photo_analyzer.os.path, "exists", lambda _p: True)
+    monkeypatch.setattr(photo_analyzer.os.path, "getsize", lambda _p: 10)
+    monkeypatch.setattr(photo_analyzer.os.path, "getmtime", lambda _p: 0)
+
+    payload = json.dumps([{"ImageWidth": 100, "ImageHeight": 50, "DateTimeOriginal": "2024:01:02 00:00:00"}])
+
+    class DummyResult:
+        stdout = payload
+
+    monkeypatch.setattr(photo_analyzer.subprocess, "run", lambda *_a, **_k: DummyResult())
+    metadata = photo_analyzer.extract_metadata("C:/file.jpg", "C:/exiftool")
+    assert metadata["Width"] == 100
+    assert metadata["Height"] == 50
+
+
+def test_validate_against_limits__video_skips():
+    metadata = {"Type": photo_analyzer.TYPE_VIDEO}
+    limits = [{"Banka": "Test"}]
+    results = photo_analyzer.validate_against_limits(metadata, limits)
+    assert results["Test"] is True
+
+
+def test_validate_against_limits__missing_dims():
+    metadata = {"Type": photo_analyzer.TYPE_PHOTO}
+    limits = [{"Banka": "Test"}]
+    results = photo_analyzer.validate_against_limits(metadata, limits)
+    assert results["Test"] is True

--- a/updatemediadatabase/tests/unit/test_regex_definitions__scenarios.py
+++ b/updatemediadatabase/tests/unit/test_regex_definitions__scenarios.py
@@ -1,0 +1,23 @@
+"""
+Unit tests for updatemedialdatabaselib/regex_definitions.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "updatemediadatabase"
+sys.path.insert(0, str(package_root))
+
+from updatemedialdatabaselib import regex_definitions
+
+
+def test_any_edit_pattern_matches():
+    assert regex_definitions.ANY_EDIT_PATTERN.search("file_bw.jpg") is not None
+
+
+def test_original_filename_pattern():
+    match = regex_definitions.ORIGINAL_FILENAME_PATTERN.match("IMG_0001_bw.jpg")
+    assert match is not None

--- a/updatemediadatabase/tests/unit/test_shared_csv_operations__scenarios.py
+++ b/updatemediadatabase/tests/unit/test_shared_csv_operations__scenarios.py
@@ -1,0 +1,32 @@
+"""
+Unit tests for updatemediadatabase/shared/csv_operations.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "updatemediadatabase"
+sys.path.insert(0, str(package_root))
+
+import shared.csv_operations as csv_operations
+
+
+def test_load_csv__missing_file(monkeypatch):
+    monkeypatch.setattr(csv_operations.os.path, "exists", lambda _p: False)
+    assert csv_operations.load_csv("missing.csv") == []
+
+
+def test_save_csv__missing_sanitizer_raises(monkeypatch, tmp_path):
+    file_path = tmp_path / "data.csv"
+    records = [{"a": "b"}]
+
+    monkeypatch.setattr(csv_operations.os.path, "exists", lambda _p: False)
+    try:
+        csv_operations.save_csv(str(file_path), records, backup=False)
+    except Exception as exc:
+        assert "sanitize_records" in str(exc) or isinstance(exc, Exception)
+    else:
+        raise AssertionError("Expected exception for missing sanitize_records")

--- a/updatemediadatabase/tests/unit/test_shared_csv_sanitizer__scenarios.py
+++ b/updatemediadatabase/tests/unit/test_shared_csv_sanitizer__scenarios.py
@@ -1,0 +1,21 @@
+"""
+Unit tests for updatemediadatabase/shared/csv_sanitizer.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "updatemediadatabase"
+sys.path.insert(0, str(package_root))
+
+from shared.csv_sanitizer import sanitize_field, is_dangerous
+
+
+def test_sanitize_field__dangerous_prefix():
+    assert sanitize_field("=1+1") == "'=1+1"
+
+
+def test_is_dangerous__safe_and_unsafe():
+    assert is_dangerous("=1+1") is True
+    assert is_dangerous("safe") is False

--- a/updatemediadatabase/tests/unit/test_shared_file_operations__scenarios.py
+++ b/updatemediadatabase/tests/unit/test_shared_file_operations__scenarios.py
@@ -1,0 +1,29 @@
+"""
+Unit tests for updatemediadatabase/shared/file_operations.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "updatemediadatabase"
+sys.path.insert(0, str(package_root))
+
+import shared.file_operations as file_operations
+
+
+def test_list_files__non_recursive(tmp_path):
+    (tmp_path / "a.txt").write_text("a", encoding="utf-8")
+    (tmp_path / "b.log").write_text("b", encoding="utf-8")
+
+    files = file_operations.list_files(str(tmp_path), pattern="\\.txt$", recursive=False)
+    assert any(path.endswith("a.txt") for path in files)
+    assert all("b.log" not in path for path in files)
+
+
+def test_ensure_directory__creates(tmp_path):
+    target = tmp_path / "nested"
+    file_operations.ensure_directory(str(target))
+    assert target.exists()

--- a/updatemediadatabase/tests/unit/test_shared_hash_utils__scenarios.py
+++ b/updatemediadatabase/tests/unit/test_shared_hash_utils__scenarios.py
@@ -1,0 +1,33 @@
+"""
+Unit tests for updatemediadatabase/shared/hash_utils.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "updatemediadatabase"
+sys.path.insert(0, str(package_root))
+
+import shared.hash_utils as hash_utils
+
+
+def test_compute_file_hash__md5(tmp_path):
+    file_path = tmp_path / "data.txt"
+    file_path.write_text("abc", encoding="utf-8")
+
+    result = hash_utils.compute_file_hash(str(file_path), method="md5")
+    assert len(result) == 32
+
+
+def test_compute_file_hash__xxhash_fallback(monkeypatch, tmp_path):
+    file_path = tmp_path / "data.txt"
+    file_path.write_text("abc", encoding="utf-8")
+
+    monkeypatch.setattr(hash_utils, "XXHASH_AVAILABLE", False)
+    hash_utils._xxhash_warning_logged = False
+
+    result = hash_utils.compute_file_hash(str(file_path), method="xxhash64")
+    assert len(result) == 32

--- a/updatemediadatabase/tests/unit/test_shared_logging_config__scenarios.py
+++ b/updatemediadatabase/tests/unit/test_shared_logging_config__scenarios.py
@@ -1,0 +1,37 @@
+"""
+Unit tests for updatemediadatabase/shared/logging_config.py.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "updatemediadatabase"
+sys.path.insert(0, str(package_root))
+
+import shared.logging_config as logging_config
+
+
+def test_setup_logging__configures_handlers(monkeypatch):
+    fake_json = io.StringIO('{"DEBUG":"white","INFO":"green","WARNING":"yellow","ERROR":"red","CRITICAL":"red"}')
+    monkeypatch.setattr(logging_config, "open", lambda *_a, **_k: fake_json)
+
+    class DummyFormatter:
+        def __init__(self, *_a, **_k):
+            return None
+
+    class DummyHandler:
+        def __init__(self, *_a, **_k):
+            self.formatter = None
+
+        def setFormatter(self, formatter):
+            self.formatter = formatter
+
+    monkeypatch.setattr(logging_config.colorlog, "ColoredFormatter", DummyFormatter)
+    monkeypatch.setattr(logging_config.logging, "StreamHandler", lambda: DummyHandler())
+    monkeypatch.setattr(logging_config.logging, "FileHandler", lambda *_a, **_k: DummyHandler())
+
+    logging_config.setup_logging(debug=False, log_file="log.txt")

--- a/updatemediadatabase/tests/unit/test_shared_modules__scenarios.py
+++ b/updatemediadatabase/tests/unit/test_shared_modules__scenarios.py
@@ -1,0 +1,44 @@
+"""
+Unit tests for updatemediadatabase/shared modules.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "updatemediadatabase"
+sys.path.insert(0, str(package_root))
+
+import shared.hash_utils as hash_utils
+import shared.logging_config as logging_config
+import shared.utils as utils
+
+
+def test_hash_utils__md5(tmp_path):
+    data_file = tmp_path / "data.bin"
+    data_file.write_bytes(b"abc")
+    assert len(hash_utils.compute_file_hash(str(data_file), method="md5")) == 32
+
+
+def test_logging_config__missing_config_raises(monkeypatch):
+    monkeypatch.setattr(logging_config, "open", lambda *_a, **_k: (_ for _ in ()).throw(OSError("missing")))
+    with pytest.raises(Exception):
+        logging_config.setup_logging()
+
+
+def test_utils__get_log_filename(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["C:/tools/run_me.py"])
+
+    class DummyDateTime:
+        @classmethod
+        def now(cls):
+            class Dummy:
+                def strftime(self, _fmt):
+                    return "2020-01-01_12-00-00"
+
+            return Dummy()
+
+    monkeypatch.setattr(utils, "datetime", DummyDateTime)
+    assert utils.get_log_filename("C:/logs").endswith("run_me_Log_2020-01-01_12-00-00.log")

--- a/updatemediadatabase/tests/unit/test_shared_utils__scenarios.py
+++ b/updatemediadatabase/tests/unit/test_shared_utils__scenarios.py
@@ -1,0 +1,36 @@
+"""
+Unit tests for updatemediadatabase/shared/utils.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "updatemediadatabase"
+sys.path.insert(0, str(package_root))
+
+import shared.utils as utils
+
+
+def test_get_script_name__uses_argv(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["C:/tools/run_me.py"])
+    assert utils.get_script_name() == "run_me"
+
+
+def test_get_log_filename__formats(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["C:/tools/run_me.py"])
+
+    class DummyDateTime:
+        @classmethod
+        def now(cls):
+            class Dummy:
+                def strftime(self, _fmt):
+                    return "2020-01-01_12-00-00"
+
+            return Dummy()
+
+    monkeypatch.setattr(utils, "datetime", DummyDateTime)
+    result = utils.get_log_filename("C:/logs")
+    assert result.endswith("run_me_Log_2020-01-01_12-00-00.log")

--- a/updatemediadatabase/tests/unit/test_updatemediadatabase__import.py
+++ b/updatemediadatabase/tests/unit/test_updatemediadatabase__import.py
@@ -1,0 +1,14 @@
+"""
+Import smoke test for updatemediadatabase.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "updatemediadatabase"
+sys.path.insert(0, str(package_root))
+
+
+def test_import_updatemediadatabase():
+    import updatemediadatabase  # noqa: F401

--- a/updatemediadatabase/tests/unit/test_updatemediadatabase__main__scenarios.py
+++ b/updatemediadatabase/tests/unit/test_updatemediadatabase__main__scenarios.py
@@ -1,0 +1,45 @@
+"""
+Unit tests for updatemediadatabase/updatemediadatabase.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "updatemediadatabase"
+sys.path.insert(0, str(package_root))
+
+import updatemediadatabase as main_module
+
+
+def test_split_files_by_type():
+    result = main_module.split_files_by_type(["a.jpg", "b.mp4", "c.png", "d.txt"])
+    assert "a.jpg" in result["jpg"]
+    assert "b.mp4" in result["videos"]
+    assert "c.png" in result["non_jpg_images"]
+
+
+def test_get_basename_from_filepath():
+    assert main_module.get_basename_from_filepath("C:/path/file.jpg") == "file"
+
+
+def test_main__exiftool_missing(monkeypatch):
+    args = SimpleNamespace(
+        media_csv="media.csv",
+        limits_csv="limits.csv",
+        photo_dir="C:/photos",
+        video_dir="C:/videos",
+        edit_photo_dir="C:/edit/photos",
+        edit_video_dir="C:/edit/videos",
+        log_dir="C:/logs",
+        debug=False,
+    )
+    monkeypatch.setattr(main_module, "parse_arguments", lambda: args)
+    monkeypatch.setattr(main_module, "ensure_directory", lambda _p: None)
+    monkeypatch.setattr(main_module, "setup_logging", lambda **_k: None)
+    monkeypatch.setattr(main_module, "ensure_exiftool", lambda: (_ for _ in ()).throw(RuntimeError("missing")))
+
+    assert main_module.main() is None

--- a/updatemediadatabase/tests/unit/test_updatemedialdatabaselib_imports__scenarios.py
+++ b/updatemediadatabase/tests/unit/test_updatemedialdatabaselib_imports__scenarios.py
@@ -1,0 +1,38 @@
+"""
+Import smoke tests for updatemedialdatabaselib modules.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "updatemediadatabase"
+sys.path.insert(0, str(package_root))
+
+
+def test_import_constants():
+    import updatemedialdatabaselib.constants  # noqa: F401
+
+
+def test_import_edit_utils():
+    import updatemedialdatabaselib.edit_utils  # noqa: F401
+
+
+def test_import_exif_downloader():
+    import updatemedialdatabaselib.exif_downloader  # noqa: F401
+
+
+def test_import_exif_handler():
+    import updatemedialdatabaselib.exif_handler  # noqa: F401
+
+
+def test_import_media_processor():
+    import updatemedialdatabaselib.media_processor  # noqa: F401
+
+
+def test_import_photo_analyzer():
+    import updatemedialdatabaselib.photo_analyzer  # noqa: F401
+
+
+def test_import_regex_definitions():
+    import updatemedialdatabaselib.regex_definitions  # noqa: F401

--- a/uploadtophotobanks/tests/integration/test_main_pipeline__dry_run.py
+++ b/uploadtophotobanks/tests/integration/test_main_pipeline__dry_run.py
@@ -1,0 +1,65 @@
+"""
+Integration tests for uploadtophotobanks main dry-run flow.
+"""
+
+import types
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "uploadtophotobanks"
+sys.path.insert(0, str(package_root))
+
+import uploadtophotobanks
+
+
+class DummyCredentialsManager:
+    def __init__(self, *_a, **_k):
+        pass
+
+    def list_photobanks(self):
+        return ["ShutterStock"]
+
+    def get_all_credentials(self):
+        return {"ShutterStock": {"user": "u"}}
+
+
+class DummyUploader:
+    def __init__(self, _creds):
+        self.creds = _creds
+
+    def upload_to_photobanks(self, _media_folder, photobanks, _export_dir, _dry_run):
+        return {name: {"success": 1, "failure": 0, "skipped": 0, "error": 0} for name in photobanks}
+
+
+def test_main_dry_run_success(monkeypatch):
+    args = types.SimpleNamespace(
+        media_folder="X:/media",
+        export_dir="X:/export",
+        log_dir="X:/logs",
+        credentials_file="X:/creds.json",
+        debug=False,
+        dry_run=True,
+        all=False,
+        shutterstock=True,
+        pond5=False,
+        rf123=False,
+        depositphotos=False,
+        alamy=False,
+        dreamstime=False,
+        adobestock=False,
+        canstockphoto=False,
+        setup_credentials=False,
+        test_connections=False,
+        list_uploadable=False,
+        create_credentials_template=False,
+    )
+
+    monkeypatch.setattr(uploadtophotobanks, "parse_arguments", lambda: args)
+    monkeypatch.setattr(uploadtophotobanks, "setup_logging", lambda **_k: None)
+    monkeypatch.setattr(uploadtophotobanks, "get_log_filename", lambda _p: "log.txt")
+    monkeypatch.setattr(uploadtophotobanks, "CredentialsManager", DummyCredentialsManager)
+    monkeypatch.setattr(uploadtophotobanks, "PhotobankUploader", DummyUploader)
+    monkeypatch.setattr(uploadtophotobanks, "validate_input_files", lambda _a: True)
+
+    assert uploadtophotobanks.main() == 0

--- a/uploadtophotobanks/tests/performance/test_filter_files_for_photobank__bulk.py
+++ b/uploadtophotobanks/tests/performance/test_filter_files_for_photobank__bulk.py
@@ -1,0 +1,20 @@
+"""
+Performance-oriented tests for file filtering per photobank.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "uploadtophotobanks"
+sys.path.insert(0, str(package_root))
+
+from uploadtophotobanksslib.uploader import PhotobankUploader
+
+
+def test_filter_files_for_photobank_bulk():
+    uploader = PhotobankUploader(credentials={})
+    media_files = [f"C:/media/file_{i}.jpg" for i in range(300)]
+    media_files += [f"C:/media/file_{i}.mp4" for i in range(200)]
+    filtered = uploader._filter_files_for_photobank(media_files, "ShutterStock")
+    assert len(filtered) >= 300

--- a/uploadtophotobanks/tests/security/test_validate_input_files__missing_paths.py
+++ b/uploadtophotobanks/tests/security/test_validate_input_files__missing_paths.py
@@ -1,0 +1,23 @@
+"""
+Security-focused tests for input validation.
+"""
+
+import types
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "uploadtophotobanks"
+sys.path.insert(0, str(package_root))
+
+import uploadtophotobanks
+
+
+def test_validate_input_files_missing_media(monkeypatch):
+    args = types.SimpleNamespace(
+        media_folder="X:/missing_media",
+        export_dir="X:/export",
+    )
+
+    monkeypatch.setattr(uploadtophotobanks.os.path, "exists", lambda _p: False)
+    assert uploadtophotobanks.validate_input_files(args) is False

--- a/uploadtophotobanks/tests/unit/__init__.py
+++ b/uploadtophotobanks/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests package for uploadtophotobanks."""

--- a/uploadtophotobanks/tests/unit/test_connection_manager__scenarios.py
+++ b/uploadtophotobanks/tests/unit/test_connection_manager__scenarios.py
@@ -1,0 +1,51 @@
+"""
+Unit tests for uploadtophotobanksslib/connection_manager.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "uploadtophotobanks"
+sys.path.insert(0, str(package_root))
+
+import uploadtophotobanksslib.connection_manager as connection_manager
+
+
+def test_detect_content_type():
+    config = {"protocol": "ftp", "host": "example", "port": 21}
+    connection_manager.PHOTOBANK_CONFIGS["TestBank"] = config
+    conn = connection_manager.FTPConnection("TestBank", {"username": "u", "password": "p"})
+
+    assert conn._detect_content_type("file.mp4") == "video"
+    assert conn._detect_content_type("file.mp3") == "audio"
+    assert conn._detect_content_type("file.jpg") == "photos"
+
+
+def test_get_connection__unsupported():
+    manager = connection_manager.ConnectionManager()
+    assert manager.get_connection("Unknown", {"username": "u", "password": "p"}) is None
+
+
+def test_get_host__uses_hosts():
+    config = {"protocol": "ftp", "hosts": {"photos": "a", "video": "b"}, "port": 21}
+    connection_manager.PHOTOBANK_CONFIGS["TestBank"] = config
+    conn = connection_manager.FTPConnection("TestBank", {"username": "u", "password": "p"})
+    assert conn._get_host("file.mp4") == "b"
+
+
+def test_disconnect_all__clears():
+    manager = connection_manager.ConnectionManager()
+
+    class DummyConn:
+        def __init__(self):
+            self.closed = False
+
+        def disconnect(self):
+            self.closed = True
+
+    manager.connections["Bank"] = DummyConn()
+    manager.disconnect_all()
+    assert manager.connections == {}

--- a/uploadtophotobanks/tests/unit/test_credentials_manager__scenarios.py
+++ b/uploadtophotobanks/tests/unit/test_credentials_manager__scenarios.py
@@ -1,0 +1,51 @@
+"""
+Unit tests for uploadtophotobanksslib/credentials_manager.py.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "uploadtophotobanks"
+sys.path.insert(0, str(package_root))
+
+import uploadtophotobanksslib.credentials_manager as credentials_manager
+
+
+def test_load_from_environment(monkeypatch):
+    monkeypatch.setenv("SHUTTERSTOCK_USERNAME", "user")
+    monkeypatch.setenv("SHUTTERSTOCK_PASSWORD", "pass")
+
+    manager = credentials_manager.CredentialsManager(credentials_file=None)
+    assert manager.get_credentials("ShutterStock") == {"username": "user", "password": "pass"}
+
+
+def test_load_missing_from_file(monkeypatch, tmp_path):
+    file_path = tmp_path / "creds.json"
+    file_path.write_text(json.dumps({"Pond5": {"username": "u", "password": "p"}}), encoding="utf-8")
+
+    manager = credentials_manager.CredentialsManager(credentials_file=str(file_path))
+    assert manager.get_credentials("Pond5") == {"username": "u", "password": "p"}
+
+
+def test_save_and_remove_credentials(tmp_path):
+    file_path = tmp_path / "creds.json"
+    manager = credentials_manager.CredentialsManager(credentials_file=str(file_path))
+    manager.set_credentials("Test", "u", "p")
+    assert manager.save_credentials() is True
+    assert manager.remove_credentials("Test") is True
+
+
+def test_validate_credentials_format():
+    manager = credentials_manager.CredentialsManager(credentials_file=None)
+    manager.set_credentials("AdobeStock", "not-numeric", "p")
+    assert manager.validate_credentials_format("AdobeStock") is True
+
+
+def test_create_credentials_template(tmp_path):
+    file_path = tmp_path / "template.json"
+    manager = credentials_manager.CredentialsManager(credentials_file=None)
+    assert manager.create_credentials_template(str(file_path)) is True

--- a/uploadtophotobanks/tests/unit/test_file_validator__scenarios.py
+++ b/uploadtophotobanks/tests/unit/test_file_validator__scenarios.py
@@ -1,0 +1,78 @@
+"""
+Unit tests for uploadtophotobanksslib/file_validator.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "uploadtophotobanks"
+sys.path.insert(0, str(package_root))
+
+import uploadtophotobanksslib.file_validator as file_validator
+from uploadtophotobanksslib.file_validator import FileValidator
+
+
+class DummyImage:
+    def __init__(self, mode="RGB", width=100, height=100, fmt="JPEG"):
+        self.mode = mode
+        self.width = width
+        self.height = height
+        self.format = fmt
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+
+def test_validate_file_for_photobank__missing_file(monkeypatch):
+    validator = FileValidator()
+    monkeypatch.setattr(file_validator.os.path, "exists", lambda _p: False)
+    assert validator.validate_file_for_photobank("C:/missing.jpg", "ShutterStock") is False
+
+
+def test_validate_file_for_photobank__unsupported_photobank(monkeypatch):
+    validator = FileValidator()
+    monkeypatch.setattr(file_validator.os.path, "exists", lambda _p: True)
+    assert validator.validate_file_for_photobank("C:/file.jpg", "Unknown") is False
+
+
+def test_validate_file_for_photobank__unsupported_extension(monkeypatch):
+    validator = FileValidator()
+    monkeypatch.setattr(file_validator.os.path, "exists", lambda _p: True)
+    assert validator.validate_file_for_photobank("C:/file.txt", "ShutterStock") is False
+
+
+def test_validate_image__bad_mode(monkeypatch):
+    validator = FileValidator()
+    monkeypatch.setattr(file_validator.os.path, "exists", lambda _p: True)
+    monkeypatch.setattr(file_validator.os.path, "getsize", lambda _p: 10)
+    monkeypatch.setattr(file_validator.Image, "open", lambda _p: DummyImage(mode="CMYK"))
+
+    assert validator.validate_file_for_photobank("C:/file.jpg", "ShutterStock") is False
+
+
+def test_validate_video__size_limit(monkeypatch):
+    validator = FileValidator()
+    monkeypatch.setattr(file_validator.os.path, "exists", lambda _p: True)
+    monkeypatch.setattr(file_validator.os.path, "getsize", lambda _p: 5 * 1024 * 1024 * 1024)
+    assert validator.validate_file_for_photobank("C:/file.mp4", "ShutterStock") is False
+
+
+def test_validate_vector__warns_missing_jpeg(monkeypatch):
+    validator = FileValidator()
+    monkeypatch.setattr(file_validator.os.path, "exists", lambda _p: True)
+    monkeypatch.setattr(file_validator.os.path, "getsize", lambda _p: 10)
+    assert validator.validate_file_for_photobank("C:/file.eps", "123RF") is True
+
+
+def test_clear_cache_and_get_file_info():
+    validator = FileValidator()
+    validator.image_cache["file"] = {"width": 1}
+    assert validator.get_file_info("file") == {"width": 1}
+    validator.clear_cache()
+    assert validator.get_file_info("file") is None

--- a/uploadtophotobanks/tests/unit/test_shared_csv_sanitizer__scenarios.py
+++ b/uploadtophotobanks/tests/unit/test_shared_csv_sanitizer__scenarios.py
@@ -1,0 +1,21 @@
+"""
+Unit tests for uploadtophotobanks/shared/csv_sanitizer.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "uploadtophotobanks"
+sys.path.insert(0, str(package_root))
+
+from shared.csv_sanitizer import sanitize_field, is_dangerous
+
+
+def test_sanitize_field__dangerous_prefix():
+    assert sanitize_field("=1+1") == "'=1+1"
+
+
+def test_is_dangerous__safe_and_unsafe():
+    assert is_dangerous("=1+1") is True
+    assert is_dangerous("safe") is False

--- a/uploadtophotobanks/tests/unit/test_shared_file_operations__scenarios.py
+++ b/uploadtophotobanks/tests/unit/test_shared_file_operations__scenarios.py
@@ -1,0 +1,29 @@
+"""
+Unit tests for uploadtophotobanks/shared/file_operations.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "uploadtophotobanks"
+sys.path.insert(0, str(package_root))
+
+import shared.file_operations as file_operations
+
+
+def test_list_files__non_recursive(tmp_path):
+    (tmp_path / "a.txt").write_text("a", encoding="utf-8")
+    (tmp_path / "b.log").write_text("b", encoding="utf-8")
+
+    files = file_operations.list_files(str(tmp_path), pattern="\\.txt$", recursive=False)
+    assert any(path.endswith("a.txt") for path in files)
+    assert all("b.log" not in path for path in files)
+
+
+def test_ensure_directory__creates(tmp_path):
+    target = tmp_path / "nested"
+    file_operations.ensure_directory(str(target))
+    assert target.exists()

--- a/uploadtophotobanks/tests/unit/test_shared_hash_utils__scenarios.py
+++ b/uploadtophotobanks/tests/unit/test_shared_hash_utils__scenarios.py
@@ -1,0 +1,33 @@
+"""
+Unit tests for uploadtophotobanks/shared/hash_utils.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "uploadtophotobanks"
+sys.path.insert(0, str(package_root))
+
+import shared.hash_utils as hash_utils
+
+
+def test_compute_file_hash__md5(tmp_path):
+    file_path = tmp_path / "data.txt"
+    file_path.write_text("abc", encoding="utf-8")
+
+    result = hash_utils.compute_file_hash(str(file_path), method="md5")
+    assert len(result) == 32
+
+
+def test_compute_file_hash__xxhash_fallback(monkeypatch, tmp_path):
+    file_path = tmp_path / "data.txt"
+    file_path.write_text("abc", encoding="utf-8")
+
+    monkeypatch.setattr(hash_utils, "XXHASH_AVAILABLE", False)
+    hash_utils._xxhash_warning_logged = False
+
+    result = hash_utils.compute_file_hash(str(file_path), method="xxhash64")
+    assert len(result) == 32

--- a/uploadtophotobanks/tests/unit/test_shared_logging_config__scenarios.py
+++ b/uploadtophotobanks/tests/unit/test_shared_logging_config__scenarios.py
@@ -1,0 +1,37 @@
+"""
+Unit tests for uploadtophotobanks/shared/logging_config.py.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "uploadtophotobanks"
+sys.path.insert(0, str(package_root))
+
+import shared.logging_config as logging_config
+
+
+def test_setup_logging__configures_handlers(monkeypatch):
+    fake_json = io.StringIO('{"DEBUG":"white","INFO":"green","WARNING":"yellow","ERROR":"red","CRITICAL":"red"}')
+    monkeypatch.setattr(logging_config, "open", lambda *_a, **_k: fake_json)
+
+    class DummyFormatter:
+        def __init__(self, *_a, **_k):
+            return None
+
+    class DummyHandler:
+        def __init__(self, *_a, **_k):
+            self.formatter = None
+
+        def setFormatter(self, formatter):
+            self.formatter = formatter
+
+    monkeypatch.setattr(logging_config.colorlog, "ColoredFormatter", DummyFormatter)
+    monkeypatch.setattr(logging_config.logging, "StreamHandler", lambda: DummyHandler())
+    monkeypatch.setattr(logging_config.logging, "FileHandler", lambda *_a, **_k: DummyHandler())
+
+    logging_config.setup_logging(debug=False, log_file="log.txt")

--- a/uploadtophotobanks/tests/unit/test_shared_modules__scenarios.py
+++ b/uploadtophotobanks/tests/unit/test_shared_modules__scenarios.py
@@ -1,0 +1,44 @@
+"""
+Unit tests for uploadtophotobanks/shared modules.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "uploadtophotobanks"
+sys.path.insert(0, str(package_root))
+
+import shared.hash_utils as hash_utils
+import shared.logging_config as logging_config
+import shared.utils as utils
+
+
+def test_hash_utils__md5(tmp_path):
+    data_file = tmp_path / "data.bin"
+    data_file.write_bytes(b"abc")
+    assert len(hash_utils.compute_file_hash(str(data_file), method="md5")) == 32
+
+
+def test_logging_config__missing_config_raises(monkeypatch):
+    monkeypatch.setattr(logging_config, "open", lambda *_a, **_k: (_ for _ in ()).throw(OSError("missing")))
+    with pytest.raises(Exception):
+        logging_config.setup_logging()
+
+
+def test_utils__get_log_filename(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["C:/tools/run_me.py"])
+
+    class DummyDateTime:
+        @classmethod
+        def now(cls):
+            class Dummy:
+                def strftime(self, _fmt):
+                    return "2020-01-01_12-00-00"
+
+            return Dummy()
+
+    monkeypatch.setattr(utils, "datetime", DummyDateTime)
+    assert utils.get_log_filename("C:/logs").endswith("run_me_Log_2020-01-01_12-00-00.log")

--- a/uploadtophotobanks/tests/unit/test_shared_utils__scenarios.py
+++ b/uploadtophotobanks/tests/unit/test_shared_utils__scenarios.py
@@ -1,0 +1,36 @@
+"""
+Unit tests for uploadtophotobanks/shared/utils.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "uploadtophotobanks"
+sys.path.insert(0, str(package_root))
+
+import shared.utils as utils
+
+
+def test_get_script_name__uses_argv(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["C:/tools/run_me.py"])
+    assert utils.get_script_name() == "run_me"
+
+
+def test_get_log_filename__formats(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["C:/tools/run_me.py"])
+
+    class DummyDateTime:
+        @classmethod
+        def now(cls):
+            class Dummy:
+                def strftime(self, _fmt):
+                    return "2020-01-01_12-00-00"
+
+            return Dummy()
+
+    monkeypatch.setattr(utils, "datetime", DummyDateTime)
+    result = utils.get_log_filename("C:/logs")
+    assert result.endswith("run_me_Log_2020-01-01_12-00-00.log")

--- a/uploadtophotobanks/tests/unit/test_uploader__scenarios.py
+++ b/uploadtophotobanks/tests/unit/test_uploader__scenarios.py
@@ -1,0 +1,63 @@
+"""
+Unit tests for uploadtophotobanksslib/uploader.py.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "uploadtophotobanks"
+sys.path.insert(0, str(package_root))
+
+import uploadtophotobanksslib.uploader as uploader
+
+
+def test_scan_media_folder__filters_extensions(tmp_path, monkeypatch):
+    monkeypatch.setattr(uploader, "PHOTOBANK_CONFIGS", {"Bank": {"supported_formats": [".jpg"]}})
+    (tmp_path / "a.jpg").write_text("x", encoding="utf-8")
+    (tmp_path / "b.txt").write_text("x", encoding="utf-8")
+
+    up = uploader.PhotobankUploader(credentials={})
+    result = up._scan_media_folder(str(tmp_path))
+    assert len(result) == 1
+    assert result[0].endswith("a.jpg")
+
+
+def test_filter_files_for_photobank(monkeypatch):
+    monkeypatch.setattr(uploader, "PHOTOBANK_CONFIGS", {"Bank": {"supported_formats": [".jpg"]}})
+    up = uploader.PhotobankUploader(credentials={})
+
+    files = ["C:/a.jpg", "C:/b.mp4"]
+    result = up._filter_files_for_photobank(files, "Bank")
+    assert result == ["C:/a.jpg"]
+
+
+def test_get_target_directory():
+    up = uploader.PhotobankUploader(credentials={})
+    uploader.PHOTOBANK_CONFIGS["Alamy"] = {"directories": {"vectors": "/Vectors", "stock": "/Stock"}}
+    assert up._get_target_directory("C:/file.eps", "Alamy") == "/Vectors"
+
+
+def test_get_uploadable_files_count(monkeypatch):
+    up = uploader.PhotobankUploader(credentials={})
+    monkeypatch.setattr(uploader, "load_csv", lambda _p: [{"File": "x", "Bank status": uploader.VALID_STATUS_FOR_UPLOAD, "Cesta": "C:/file.jpg"}])
+    monkeypatch.setattr(uploader, "get_status_column", lambda _p: "Bank status")
+    monkeypatch.setattr(uploader.os.path, "exists", lambda _p: True)
+
+    assert up.get_uploadable_files_count("csv.csv", "Bank") == 1
+
+
+def test_validate_credentials(monkeypatch):
+    up = uploader.PhotobankUploader(credentials={"Bank": {"username": "u", "password": "p"}})
+
+    class DummyConnection:
+        def is_connected(self):
+            return True
+
+    up.connection_manager.get_connection = lambda *_a, **_k: DummyConnection()
+    up.connection_manager.disconnect = lambda *_a, **_k: None
+    assert up.validate_credentials("Bank") is True

--- a/uploadtophotobanks/tests/unit/test_uploadtophotobanks__import.py
+++ b/uploadtophotobanks/tests/unit/test_uploadtophotobanks__import.py
@@ -1,0 +1,14 @@
+"""
+Import smoke test for uploadtophotobanks.py.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "uploadtophotobanks"
+sys.path.insert(0, str(package_root))
+
+
+def test_import_uploadtophotobanks():
+    import uploadtophotobanks  # noqa: F401

--- a/uploadtophotobanks/tests/unit/test_uploadtophotobanks__main__scenarios.py
+++ b/uploadtophotobanks/tests/unit/test_uploadtophotobanks__main__scenarios.py
@@ -1,0 +1,35 @@
+"""
+Unit tests for uploadtophotobanks/uploadtophotobanks.py helpers.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "uploadtophotobanks"
+sys.path.insert(0, str(package_root))
+
+import uploadtophotobanks as main_module
+
+
+def test_get_selected_photobanks__all(monkeypatch):
+    args = SimpleNamespace(
+        all=True, shutterstock=False, pond5=False, rf123=False, depositphotos=False,
+        alamy=False, dreamstime=False, adobestock=False, canstockphoto=False
+    )
+
+    class DummyCreds:
+        def list_photobanks(self):
+            return ["ShutterStock", "Pond5"]
+
+    selected = main_module.get_selected_photobanks(args, DummyCreds())
+    assert selected == ["ShutterStock", "Pond5"]
+
+
+def test_validate_input_files(monkeypatch):
+    args = SimpleNamespace(media_folder="C:/media", export_dir="C:/export")
+    monkeypatch.setattr(main_module.os.path, "exists", lambda _p: False)
+    assert main_module.validate_input_files(args) is False

--- a/uploadtophotobanks/tests/unit/test_uploadtophotobanks_constants__sanity.py
+++ b/uploadtophotobanks/tests/unit/test_uploadtophotobanks_constants__sanity.py
@@ -1,0 +1,22 @@
+"""
+Sanity tests for uploadtophotobanksslib/constants.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "uploadtophotobanks"
+sys.path.insert(0, str(package_root))
+
+from uploadtophotobanksslib import constants
+
+
+def test_get_status_column():
+    assert constants.get_status_column("Bank") == "Bank status"
+
+
+def test_get_category_column():
+    assert constants.get_category_column("Bank") == "Bank kategorie"

--- a/uploadtophotobanks/tests/unit/test_uploadtophotobanksslib_imports__scenarios.py
+++ b/uploadtophotobanks/tests/unit/test_uploadtophotobanksslib_imports__scenarios.py
@@ -1,0 +1,30 @@
+"""
+Import smoke tests for uploadtophotobanksslib modules.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[3]
+package_root = project_root / "uploadtophotobanks"
+sys.path.insert(0, str(package_root))
+
+
+def test_import_connection_manager():
+    import uploadtophotobanksslib.connection_manager  # noqa: F401
+
+
+def test_import_constants():
+    import uploadtophotobanksslib.constants  # noqa: F401
+
+
+def test_import_credentials_manager():
+    import uploadtophotobanksslib.credentials_manager  # noqa: F401
+
+
+def test_import_file_validator():
+    import uploadtophotobanksslib.file_validator  # noqa: F401
+
+
+def test_import_uploader():
+    import uploadtophotobanksslib.uploader  # noqa: F401


### PR DESCRIPTION
## Why\nDreamstime sometimes picks unrelated categories due to prompt pressure and     partial-match parsing.\n\n## What\n- Make category prompt stricter about relevance\n- Remove inspiration wording\n- Exact-match category parsing\n- Filter Dreamstime Web Design Graphics for JPG\n\n##     Testing\n- Not run