### PR TITLE
Add script to add editorial tags to PhotoMedia.csv

### DIFF
--- a/givephotobankreadymediafiles/givephotobankreadymediafileslib/batch_manager.py
+++ b/givephotobankreadymediafiles/givephotobankreadymediafileslib/batch_manager.py
@@ -497,7 +497,8 @@ def _process_batch_results(batch_state: BatchState, results: List[Dict[str, obje
 
 
 def _generate_alternatives_for_file(registry: BatchRegistry, media_csv: str,
-                                    original_path: str, original_metadata: Dict[str, object]) -> None:
+                                    original_path: str, original_metadata: Dict[str, object],
+                                    editorial_data: Optional[Dict[str, str]] = None) -> None:
     normalized = _normalize_path(original_path)
     if registry.data.get("alternatives_generated", {}).get(normalized):
         return
@@ -565,7 +566,7 @@ def _generate_alternatives_for_file(registry: BatchRegistry, media_csv: str,
                 custom_id,
                 user_description="",
                 editorial=editorial_flag,
-                editorial_data=None,
+                editorial_data=editorial_data,  # Pass editorial_data from original
                 entry_type="alternative",
                 extra={
                     "edit_tag": edit_tag,
@@ -601,7 +602,8 @@ def _queue_alternatives_from_batch(batch_state: BatchState, registry: BatchRegis
         if not original_path:
             continue
         original_metadata = item.get("result") or {}
-        _generate_alternatives_for_file(registry, media_csv, original_path, original_metadata)
+        editorial_data = item.get("editorial_data")  # Extract editorial_data from batch entry
+        _generate_alternatives_for_file(registry, media_csv, original_path, original_metadata, editorial_data)
 
 
 def _finalize_alternative_batches(registry: BatchRegistry) -> None:

--- a/givephotobankreadymediafiles/preparemediafile.py
+++ b/givephotobankreadymediafiles/preparemediafile.py
@@ -281,7 +281,8 @@ def main():
                 if is_editorial and original_description:
                     import re
                     # Pattern: "CITY, COUNTRY - DD MM YYYY: "
-                    match = re.match(r'^([A-Z\s]+),\s*([A-Z\s]+)\s*-\s*(\d{2}\s+\d{2}\s+\d{4}):\s*', original_description)
+                    # City can be multi-word (e.g., "Cesky Krumlov")
+                    match = re.match(r'^([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*),\s*([A-Z][a-z]+)\s*-\s*(\d{2}\s+\d{2}\s+\d{4}):\s*', original_description)
                     if match:
                         editorial_data = {
                             'city': match.group(1).strip(),

--- a/givephotobankreadymediafiles/preparemediafile.py
+++ b/givephotobankreadymediafiles/preparemediafile.py
@@ -276,6 +276,20 @@ def main():
                 original_keywords_list = keywords
                 is_editorial = saved_metadata.get('editorial', False)
 
+                # Extract full editorial_data from description if present
+                editorial_data = None
+                if is_editorial and original_description:
+                    import re
+                    # Pattern: "CITY, COUNTRY - DD MM YYYY: "
+                    match = re.match(r'^([A-Z\s]+),\s*([A-Z\s]+)\s*-\s*(\d{2}\s+\d{2}\s+\d{4}):\s*', original_description)
+                    if match:
+                        editorial_data = {
+                            'city': match.group(1).strip(),
+                            'country': match.group(2).strip(),
+                            'date': match.group(3).strip()
+                        }
+                        logging.debug(f"Extracted editorial data from description: {editorial_data}")
+
                 # Generate metadata ONCE per edit tag (not per file)
                 edit_metadata = {}  # Store metadata for each edit tag
 
@@ -310,7 +324,7 @@ def main():
 
                                 alt_description = ai_generator.generate_description_for_alternative(
                                     args.file, edit_tag, original_title, original_description,
-                                    editorial_data={'is_editorial': is_editorial} if is_editorial else None
+                                    editorial_data=editorial_data  # Pass full editorial_data with city, country, date
                                 )
                                 logging.debug(f"Generated description for {edit_tag}: {alt_description[:50]}...")
 

--- a/givephotobankreadymediafiles/scripts/add_editorial_tags_to_photomedia.py
+++ b/givephotobankreadymediafiles/scripts/add_editorial_tags_to_photomedia.py
@@ -14,9 +14,8 @@ import sys
 import argparse
 import re
 from pathlib import Path
-from typing import Dict, List, Set, Optional, Tuple
+from typing import Dict, List, Set, Optional
 from datetime import datetime
-from collections import defaultdict
 
 # Progress bar
 try:

--- a/givephotobankreadymediafiles/scripts/add_editorial_tags_to_photomedia.py
+++ b/givephotobankreadymediafiles/scripts/add_editorial_tags_to_photomedia.py
@@ -127,7 +127,8 @@ def collect_editorial_cities(csv_path: str) -> Set[str]:
                 continue
 
             # Extract city from editorial tag pattern: "CITY, Czech - DD MM YYYY: "
-            match = re.match(r'^([A-Za-z]+),\s*Czech\s*-\s*\d{2}\s+\d{2}\s+\d{4}:\s*', description)
+            # Pattern supports multi-word cities: "Cesky Krumlov", "New York", etc.
+            match = re.match(r'^([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*),\s*Czech\s*-\s*\d{2}\s+\d{2}\s+\d{4}:\s*', description)
             if match:
                 city = match.group(1).strip()
                 if city:
@@ -214,7 +215,7 @@ def extract_exif_date(file_path: str) -> Optional[str]:
     """
     try:
         with Image.open(file_path) as img:
-            exif_data = img._getexif()
+            exif_data = img.getexif()
             if not exif_data:
                 return None
 

--- a/givephotobankreadymediafiles/scripts/add_editorial_tags_to_photomedia.py
+++ b/givephotobankreadymediafiles/scripts/add_editorial_tags_to_photomedia.py
@@ -13,7 +13,6 @@ Usage:
 import sys
 import argparse
 import re
-import csv
 from pathlib import Path
 from typing import Dict, List, Set, Optional, Tuple
 from datetime import datetime
@@ -43,6 +42,7 @@ from givephotobankreadymediafileslib.constants import (
     COL_DESCRIPTION,
     COL_PATH,
     DEFAULT_MEDIA_CSV_PATH,
+    MAX_DESCRIPTION_LENGTH,
 )
 from shared.config import Config
 from shared.file_operations import load_csv, save_csv_with_backup
@@ -60,9 +60,6 @@ except ImportError:
 import logging
 setup_logging(debug=False, log_file="logs/add_editorial_tags_to_photomedia.log")
 logger = logging.getLogger(__name__)
-
-# Constants
-MAX_DESCRIPTION_LENGTH = 200
 
 
 def collect_editorial_cities(csv_path: str) -> Set[str]:

--- a/givephotobankreadymediafiles/scripts/add_editorial_tags_to_photomedia.py
+++ b/givephotobankreadymediafiles/scripts/add_editorial_tags_to_photomedia.py
@@ -44,7 +44,7 @@ from givephotobankreadymediafileslib.constants import (
     DEFAULT_MEDIA_CSV_PATH,
     MAX_DESCRIPTION_LENGTH,
 )
-from shared.config import Config
+from shared.config import get_config
 from shared.file_operations import load_csv, save_csv_with_backup
 from shared.logging_config import setup_logging
 
@@ -680,7 +680,7 @@ def main():
     ai_generator = None
     if not args.dry_run:
         try:
-            config = Config()
+            config = get_config()
             provider, model = config.get_default_ai_model()
             logger.info(f"Initializing AI generator: {provider}/{model}")
             model_key = f"{provider}/{model}"

--- a/givephotobankreadymediafiles/scripts/add_editorial_tags_to_photomedia.py
+++ b/givephotobankreadymediafiles/scripts/add_editorial_tags_to_photomedia.py
@@ -1,0 +1,689 @@
+#!/usr/bin/env python3
+"""
+Add Missing Editorial Tags to PhotoMedia.csv
+
+Scans batches for editorial cities, finds photos in PhotoMedia.csv that mention
+those cities in title/description, and adds editorial tags + regenerates descriptions.
+
+Usage:
+    python add_editorial_tags_to_photomedia.py --dry-run   # Preview changes
+    python add_editorial_tags_to_photomedia.py             # Apply changes
+"""
+
+import sys
+import argparse
+import re
+import csv
+from pathlib import Path
+from typing import Dict, List, Set, Optional, Tuple
+from datetime import datetime
+from collections import defaultdict
+
+# Progress bar
+try:
+    from tqdm import tqdm
+except ImportError:
+    print("WARNING: tqdm not installed. Install with: pip install tqdm")
+    # Fallback: no progress bar
+    def tqdm(iterable, **kwargs):
+        return iterable
+
+# Add paths for imports
+script_dir = Path(__file__).parent
+module_dir = script_dir.parent
+root_dir = module_dir.parent
+sys.path.insert(0, str(module_dir))
+sys.path.insert(0, str(root_dir))
+
+from givephotobankreadymediafileslib.batch_state import BatchState, BatchRegistry
+from givephotobankreadymediafileslib.metadata_generator import MetadataGenerator, create_metadata_generator
+from givephotobankreadymediafileslib.constants import (
+    COL_FILE,
+    COL_TITLE,
+    COL_DESCRIPTION,
+    COL_PATH,
+    DEFAULT_MEDIA_CSV_PATH,
+)
+from shared.config import Config
+from shared.file_operations import load_csv, save_csv_with_backup
+from shared.logging_config import setup_logging
+
+# PIL for EXIF extraction
+try:
+    from PIL import Image
+    from PIL.ExifTags import TAGS
+except ImportError:
+    print("ERROR: PIL/Pillow not installed. Install with: pip install Pillow")
+    sys.exit(1)
+
+# Setup logging
+import logging
+setup_logging(debug=False, log_file="logs/add_editorial_tags_to_photomedia.log")
+logger = logging.getLogger(__name__)
+
+# Constants
+MAX_DESCRIPTION_LENGTH = 200
+
+
+def collect_editorial_cities(csv_path: str) -> Set[str]:
+    """
+    Scan completed batches AND PhotoMedia.csv for unique editorial cities.
+
+    Args:
+        csv_path: Path to PhotoMedia.csv
+
+    Returns:
+        Set of city names found in editorial_data (batches) and existing editorial tags (PhotoMedia.csv)
+    """
+    import os
+    from givephotobankreadymediafileslib.constants import BATCH_STATE_DIR
+
+    cities = set()
+
+    # SOURCE 1: Completed batches
+    registry = BatchRegistry()
+    completed_batches = registry.data.get("completed_batches", [])
+
+    logger.info(f"Scanning {len(completed_batches)} completed batches for editorial cities...")
+
+    for batch_info in completed_batches:
+        batch_id = batch_info.get('batch_id')
+        if not batch_id:
+            continue
+
+        batch_dir = os.path.join(BATCH_STATE_DIR, "batches", batch_id)
+
+        if not os.path.exists(batch_dir):
+            logger.debug(f"Batch directory not found: {batch_dir}")
+            continue
+
+        try:
+            batch_state = BatchState(batch_id, batch_dir)
+
+            for file_entry in batch_state.all_files():
+                if not file_entry:
+                    continue
+                editorial_data = file_entry.get('editorial_data')
+                if editorial_data and isinstance(editorial_data, dict):
+                    city = editorial_data.get('city', '').strip()
+                    if city:
+                        cities.add(city)
+        except Exception as e:
+            logger.debug(f"Skipping batch {batch_id}: {e}")
+            continue
+
+    batch_cities_count = len(cities)
+    logger.info(f"Found {batch_cities_count} cities from completed batches")
+
+    # SOURCE 2: Existing editorial tags in PhotoMedia.csv
+    logger.info(f"Scanning PhotoMedia.csv for existing editorial tags...")
+
+    try:
+        records = load_csv(csv_path)
+
+        for record in records:
+            description = record.get(COL_DESCRIPTION, "")
+            if not description:
+                continue
+
+            # Extract city from editorial tag pattern: "CITY, Czech - DD MM YYYY: "
+            match = re.match(r'^([A-Za-z]+),\s*Czech\s*-\s*\d{2}\s+\d{2}\s+\d{4}:\s*', description)
+            if match:
+                city = match.group(1).strip()
+                if city:
+                    cities.add(city)
+
+        photomedia_cities_count = len(cities) - batch_cities_count
+        logger.info(f"Found {photomedia_cities_count} additional cities from PhotoMedia.csv")
+    except Exception as e:
+        logger.warning(f"Failed to scan PhotoMedia.csv for cities: {e}")
+
+    logger.info(f"Total: {len(cities)} unique editorial cities: {sorted(cities)}")
+    return cities
+
+
+def build_batch_description_map() -> Dict[str, str]:
+    """
+    Build mapping of file paths to their batch descriptions (for photos with editorial tags).
+
+    Returns:
+        Dict mapping file_path -> batch description with editorial tag
+    """
+    import os
+    from givephotobankreadymediafileslib.constants import BATCH_STATE_DIR
+
+    batch_descriptions = {}
+
+    # Load batch registry to get completed batches
+    registry = BatchRegistry()
+    completed_batches = registry.data.get("completed_batches", [])
+
+    logger.info(f"Building batch description map from {len(completed_batches)} completed batches...")
+
+    for batch_info in completed_batches:
+        batch_id = batch_info.get('batch_id')
+        if not batch_id:
+            continue
+
+        batch_dir = os.path.join(BATCH_STATE_DIR, "batches", batch_id)
+
+        if not os.path.exists(batch_dir):
+            logger.debug(f"Batch directory not found: {batch_dir}")
+            continue
+
+        try:
+            batch_state = BatchState(batch_id, batch_dir)
+
+            for file_entry in batch_state.all_files():
+                if not file_entry:
+                    continue
+
+                file_path = file_entry.get('file_path', '')
+                editorial_data = file_entry.get('editorial_data')
+
+                if editorial_data and isinstance(editorial_data, dict):
+                    result = file_entry.get('result', {})
+                    description = result.get('description', '')
+
+                    # Check if description has editorial tag
+                    city = editorial_data.get('city', '').strip()
+                    if city and description:
+                        pattern = rf"^{re.escape(city)},\s*Czech\s*-\s*\d{{2}}\s+\d{{2}}\s+\d{{4}}:\s*"
+                        if re.match(pattern, description, re.IGNORECASE):
+                            # Normalize path for comparison
+                            normalized_path = Path(file_path).as_posix().lower()
+                            batch_descriptions[normalized_path] = description
+        except Exception as e:
+            logger.debug(f"Skipping batch {batch_id}: {e}")
+            continue
+
+    logger.info(f"Found {len(batch_descriptions)} photos with editorial tags in batches")
+    return batch_descriptions
+
+
+def extract_exif_date(file_path: str) -> Optional[str]:
+    """
+    Extract date from EXIF metadata in DD MM YYYY format.
+    Uses PIL/Pillow (same method as batch mode).
+
+    Args:
+        file_path: Path to image file
+
+    Returns:
+        Date string in "DD MM YYYY" format or None if not found
+    """
+    try:
+        with Image.open(file_path) as img:
+            exif_data = img._getexif()
+            if not exif_data:
+                return None
+
+            for tag_id, value in exif_data.items():
+                tag = TAGS.get(tag_id, tag_id)
+                if tag == 'DateTime' and value:
+                    try:
+                        dt = datetime.strptime(value, "%Y:%m:%d %H:%M:%S")
+                        return dt.strftime("%d %m %Y")
+                    except ValueError:
+                        continue
+        return None
+    except Exception as e:
+        logger.warning(f"Failed to extract EXIF date from {file_path}: {e}")
+        return None
+
+
+def find_city_in_text(text: str, cities: Set[str]) -> Optional[str]:
+    """
+    Find if any city name appears in the given text.
+
+    Args:
+        text: Text to search in (title or description)
+        cities: Set of city names to look for
+
+    Returns:
+        First matching city name or None
+    """
+    if not text:
+        return None
+
+    text_lower = text.lower()
+
+    for city in cities:
+        # Search for city name as whole word
+        pattern = rf"\b{re.escape(city.lower())}\b"
+        if re.search(pattern, text_lower):
+            return city
+
+    return None
+
+
+def truncate_to_sentence(text: str, max_length: int) -> str:
+    """
+    Truncate text at sentence boundary before max_length.
+
+    Args:
+        text: Text to truncate
+        max_length: Maximum length
+
+    Returns:
+        Truncated text ending on sentence boundary
+    """
+    if len(text) <= max_length:
+        return text
+
+    truncated = text[:max_length]
+
+    # Find last sentence ending
+    last_period = truncated.rfind('.')
+    last_exclamation = truncated.rfind('!')
+    last_question = truncated.rfind('?')
+    last_sentence_end = max(last_period, last_exclamation, last_question)
+
+    if last_sentence_end > 0:
+        return text[:last_sentence_end + 1].strip()
+
+    # Fallback to word boundary
+    last_space = truncated.rfind(' ')
+    if last_space > 0:
+        return text[:last_space].strip() + "..."
+
+    return text[:max_length].strip() + "..."
+
+
+def regenerate_description_with_editorial(
+    file_path: str,
+    city: str,
+    exif_date: str,
+    title: str,
+    current_description: str,
+    ai_generator: MetadataGenerator
+) -> str:
+    """
+    Regenerate description with editorial tag using AI.
+
+    Args:
+        file_path: Path to image file
+        city: City name
+        exif_date: Date in "DD MM YYYY" format
+        title: Current title
+        current_description: Current description (without editorial tag)
+        ai_generator: MetadataGenerator instance
+
+    Returns:
+        New description with editorial tag
+    """
+    editorial_data = {
+        'city': city,
+        'country': 'Czech',
+        'date': exif_date
+    }
+
+    # Generate new description with AI
+    new_description = ai_generator.generate_description(
+        image_path=file_path,
+        title=title,
+        context=current_description,
+        editorial_data=editorial_data,
+        user_description=None
+    )
+
+    return new_description
+
+
+def interactive_confirmation(candidates: List[Dict]) -> List[Dict]:
+    """
+    Ask user to confirm each candidate before processing.
+
+    Args:
+        candidates: List of candidate records
+
+    Returns:
+        List of confirmed candidates
+    """
+    if not candidates:
+        return []
+
+    print(f"\n{'='*80}")
+    print(f"Found {len(candidates)} photos potentially needing editorial tags")
+    print(f"Please review each one to avoid false positives")
+    print(f"{'='*80}\n")
+
+    confirmed = []
+
+    for i, candidate in enumerate(candidates, 1):
+        print(f"\n{'-'*80}")
+        print(f"Photo {i}/{len(candidates)}")
+        print(f"{'-'*80}")
+        print(f"File: {candidate['filename']}")
+        print(f"City detected: {candidate['city']}")
+        print(f"Current title: {candidate['current_title']}")
+        print(f"Current description: {candidate['current_description'][:100]}..." if len(candidate['current_description']) > 100 else f"Current description: {candidate['current_description']}")
+        print(f"Source: {candidate['source']}")
+
+        if candidate['source'] == 'batch':
+            print(f"New description: {candidate['batch_description'][:100]}..." if len(candidate['batch_description']) > 100 else f"New description: {candidate['batch_description']}")
+        else:
+            print(f"New description: [Will be AI-generated with editorial tag: '{candidate['city']}, Czech - [DATE]: ...']")
+
+        while True:
+            response = input("\nConfirm this change? [y/n/skip/quit]: ").lower().strip()
+
+            if response == 'y':
+                confirmed.append(candidate)
+                print("✓ Confirmed")
+                break
+            elif response == 'n':
+                print("✗ Rejected")
+                break
+            elif response == 'skip':
+                print("○ Skipped")
+                break
+            elif response == 'quit':
+                print(f"\n{'='*80}")
+                print(f"Confirmation stopped. {len(confirmed)} photos confirmed so far.")
+                print(f"{'='*80}\n")
+                return confirmed
+            else:
+                print("Invalid input. Please enter 'y', 'n', 'skip', or 'quit'")
+
+    print(f"\n{'='*80}")
+    print(f"Confirmation complete: {len(confirmed)}/{len(candidates)} photos confirmed")
+    print(f"{'='*80}\n")
+
+    return confirmed
+
+
+def process_photomedia_csv(
+    csv_path: str,
+    cities: Set[str],
+    batch_descriptions: Dict[str, str],
+    ai_generator: Optional[MetadataGenerator],
+    dry_run: bool
+) -> List[Dict]:
+    """
+    Process PhotoMedia.csv and find records needing editorial tags.
+
+    Args:
+        csv_path: Path to PhotoMedia.csv
+        cities: Set of editorial cities to search for
+        batch_descriptions: Mapping of file paths to batch descriptions
+        ai_generator: MetadataGenerator instance (None for dry-run)
+        dry_run: If True, only report changes without applying
+
+    Returns:
+        List of records that were processed
+    """
+    logger.info(f"Loading PhotoMedia.csv from {csv_path}")
+    records = load_csv(csv_path)  # Returns List[Dict[str, str]]
+
+    if not records:
+        logger.warning("PhotoMedia.csv is empty or could not be loaded")
+        return []
+
+    # PHASE 1: Scan and collect candidates
+    logger.info(f"Scanning {len(records)} records for city mentions...")
+    candidates = []
+
+    for i, record in enumerate(records):
+        filename = record.get(COL_FILE, "")
+        full_path = record.get(COL_PATH, "")
+        title = record.get(COL_TITLE, "")
+        description = record.get(COL_DESCRIPTION, "")
+
+        # Skip if both title and description are empty
+        if not title and not description:
+            continue
+
+        # Search for city in title or description
+        city = find_city_in_text(title, cities)
+        if not city:
+            city = find_city_in_text(description, cities)
+
+        if not city:
+            continue
+
+        # Check if description already has editorial tag for this city
+        pattern = rf"^{re.escape(city)},\s*Czech\s*-\s*\d{{2}}\s+\d{{2}}\s+\d{{4}}:\s*"
+        if re.match(pattern, description, re.IGNORECASE):
+            # Already has correct editorial tag
+            continue
+
+        # Found a record needing editorial tag
+        normalized_path = Path(full_path).as_posix().lower() if full_path else Path(filename).as_posix().lower()
+
+        # Check if photo is in batch with editorial tag
+        if normalized_path in batch_descriptions:
+            source = "batch"
+            batch_description = batch_descriptions[normalized_path]
+        else:
+            source = "ai"
+            batch_description = None
+
+        candidates.append({
+            'record_index': i,  # Index in records list
+            'filename': filename,  # For display
+            'full_path': full_path,  # For EXIF extraction
+            'city': city,
+            'current_title': title,
+            'current_description': description,
+            'source': source,
+            'batch_description': batch_description
+        })
+
+    if not candidates:
+        logger.info("No records need editorial tags")
+        return []
+
+    logger.info(f"Found {len(candidates)} records needing editorial tags")
+
+    # Interactive confirmation (only in live mode)
+    if not dry_run:
+        logger.info("Starting interactive confirmation...")
+        candidates = interactive_confirmation(candidates)
+
+        if not candidates:
+            logger.info("No candidates confirmed. Exiting.")
+            return []
+
+        logger.info(f"{len(candidates)} candidates confirmed by user")
+
+    # PHASE 2: Process candidates with progress bar
+    processed = []
+    ai_candidates = [c for c in candidates if c['source'] == 'ai']
+    batch_candidates = [c for c in candidates if c['source'] == 'batch']
+
+    logger.info(f"  - {len(batch_candidates)} will use batch descriptions")
+    logger.info(f"  - {len(ai_candidates)} will be AI-regenerated")
+
+    # Process batch candidates (no AI needed)
+    for candidate in batch_candidates:
+        candidate['new_description'] = candidate['batch_description']
+        processed.append(candidate)
+
+        if not dry_run:
+            # Update the record dictionary directly
+            records[candidate['record_index']][COL_DESCRIPTION] = candidate['new_description']
+
+    # Process AI candidates with progress bar
+    if ai_candidates:
+        if dry_run:
+            # Dry-run: just mark for AI generation
+            for candidate in ai_candidates:
+                candidate['new_description'] = "[WILL BE AI GENERATED]"
+                processed.append(candidate)
+        else:
+            # Live mode: AI regenerate with progress bar
+            logger.info("Regenerating descriptions with AI...")
+            for candidate in tqdm(ai_candidates, desc="AI generation", unit="photo"):
+                # Extract EXIF date
+                exif_date = extract_exif_date(candidate['full_path'])
+                if not exif_date:
+                    logger.warning(f"Could not extract EXIF date from {candidate['filename']}, skipping")
+                    continue
+
+                # Regenerate with AI
+                new_description = regenerate_description_with_editorial(
+                    candidate['full_path'],
+                    candidate['city'],
+                    exif_date,
+                    candidate['current_title'],
+                    candidate['current_description'],
+                    ai_generator
+                )
+
+                candidate['new_description'] = new_description
+                processed.append(candidate)
+
+                # Update the record dictionary directly
+                records[candidate['record_index']][COL_DESCRIPTION] = new_description
+
+    if not dry_run and processed:
+        logger.info(f"Writing {len(processed)} updates to PhotoMedia.csv...")
+        save_csv_with_backup(records, csv_path)
+
+    return processed
+
+
+def print_dry_run_results(processed: List[Dict]) -> None:
+    """
+    Print dry-run results showing what would be changed.
+
+    Args:
+        processed: List of records that would be processed
+    """
+    if not processed:
+        print("\n✓ No records need editorial tags")
+        return
+
+    print(f"\n{'='*80}")
+    print(f"DRY RUN: Found {len(processed)} records needing editorial tags")
+    print(f"{'='*80}\n")
+
+    # Group by source
+    batch_sources = [p for p in processed if p['source'] == 'batch']
+    ai_sources = [p for p in processed if p['source'] == 'ai']
+
+    if batch_sources:
+        print(f"\n{len(batch_sources)} records will use batch descriptions:")
+        for rec in batch_sources[:10]:  # Show first 10
+            print(f"\n  File: {rec['filename']}")
+            print(f"  City: {rec['city']}")
+            print(f"  Current title: {rec['current_title']}")
+            print(f"  Current description: {rec['current_description']}")
+            print(f"  New description: {rec['new_description']}")
+        if len(batch_sources) > 10:
+            print(f"\n  ... and {len(batch_sources) - 10} more")
+
+    if ai_sources:
+        print(f"\n{len(ai_sources)} records will be AI-regenerated:")
+        for rec in ai_sources[:10]:  # Show first 10
+            print(f"\n  File: {rec['filename']}")
+            print(f"  City: {rec['city']}")
+            print(f"  Current title: {rec['current_title']}")
+            print(f"  Current description: {rec['current_description']}")
+        if len(ai_sources) > 10:
+            print(f"\n  ... and {len(ai_sources) - 10} more")
+
+    print(f"\n{'='*80}")
+    print(f"Total: {len(processed)} records will be updated")
+    print(f"Run without --dry-run to apply changes")
+    print(f"{'='*80}\n")
+
+
+def print_live_run_summary(processed: List[Dict]) -> None:
+    """
+    Print summary of live run results.
+
+    Args:
+        processed: List of records that were processed
+    """
+    if not processed:
+        print("\n✓ No records needed editorial tags")
+        return
+
+    batch_sources = [p for p in processed if p['source'] == 'batch']
+    ai_sources = [p for p in processed if p['source'] == 'ai']
+
+    print(f"\n{'='*80}")
+    print(f"COMPLETED: Updated {len(processed)} records in PhotoMedia.csv")
+    print(f"{'='*80}")
+    print(f"  - {len(batch_sources)} used batch descriptions")
+    print(f"  - {len(ai_sources)} AI-regenerated")
+    print(f"{'='*80}\n")
+
+
+def main():
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description="Add missing editorial tags to PhotoMedia.csv"
+    )
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='Preview changes without applying them'
+    )
+    parser.add_argument(
+        '--csv',
+        type=str,
+        default=DEFAULT_MEDIA_CSV_PATH,
+        help='Path to PhotoMedia.csv'
+    )
+
+    args = parser.parse_args()
+
+    logger.info("="*80)
+    logger.info("Add Editorial Tags to PhotoMedia.csv")
+    logger.info("="*80)
+    logger.info(f"Mode: {'DRY RUN' if args.dry_run else 'LIVE'}")
+    logger.info(f"CSV: {args.csv}")
+    logger.info("="*80)
+
+    # Step 1: Collect editorial cities from batches and PhotoMedia.csv
+    cities = collect_editorial_cities(args.csv)
+
+    if not cities:
+        logger.warning("No editorial cities found. Nothing to do.")
+        return 0
+
+    # Step 2: Build batch description map
+    batch_descriptions = build_batch_description_map()
+
+    # Step 3: Initialize AI generator (only for live mode)
+    ai_generator = None
+    if not args.dry_run:
+        try:
+            config = Config()
+            provider, model = config.get_default_ai_model()
+            logger.info(f"Initializing AI generator: {provider}/{model}")
+            model_key = f"{provider}/{model}"
+            api_key = config.get_ai_api_key(provider)
+            ai_generator = create_metadata_generator(model_key, api_key=api_key)
+        except Exception as e:
+            logger.error(f"Failed to initialize AI generator: {e}")
+            return 1
+
+    # Step 4: Process PhotoMedia.csv
+    try:
+        processed = process_photomedia_csv(
+            args.csv,
+            cities,
+            batch_descriptions,
+            ai_generator,
+            args.dry_run
+        )
+    except Exception as e:
+        logger.error(f"Error processing PhotoMedia.csv: {e}")
+        return 1
+
+    # Step 5: Print results
+    if args.dry_run:
+        print_dry_run_results(processed)
+    else:
+        print_live_run_summary(processed)
+
+    logger.info("Done")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/givephotobankreadymediafiles/scripts/add_editorial_tags_to_photomedia.py
+++ b/givephotobankreadymediafiles/scripts/add_editorial_tags_to_photomedia.py
@@ -640,8 +640,13 @@ def print_live_run_summary(processed: List[Dict]) -> None:
     print(f"{'='*80}\n")
 
 
-def main():
-    """Main entry point."""
+def main() -> int:
+    """
+    Main entry point for adding editorial tags to PhotoMedia.csv.
+
+    Returns:
+        Exit code (0 for success, 1 for error)
+    """
     parser = argparse.ArgumentParser(
         description="Add missing editorial tags to PhotoMedia.csv"
     )

--- a/givephotobankreadymediafiles/scripts/add_missing_editorial_tags.py
+++ b/givephotobankreadymediafiles/scripts/add_missing_editorial_tags.py
@@ -667,8 +667,13 @@ def bulk_update_batches(confirmed_photos: List[Dict], registry: BatchRegistry, m
     print(f"{'='*70}")
 
 
-def main():
-    """Main entry point for the script."""
+def main() -> int:
+    """
+    Main entry point for the script.
+
+    Returns:
+        Exit code (0 for success, 1 for error)
+    """
     parser = argparse.ArgumentParser(
         description="Add missing editorial tags to photos in completed batches",
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/givephotobankreadymediafiles/scripts/add_missing_editorial_tags.py
+++ b/givephotobankreadymediafiles/scripts/add_missing_editorial_tags.py
@@ -45,6 +45,7 @@ from givephotobankreadymediafileslib.constants import (
     MAX_DESCRIPTION_LENGTH,
 )
 from shared.config import get_config
+from shared.file_operations import save_json_with_backup
 from givephotobankreadymediafileslib.metadata_generator import create_metadata_generator
 
 
@@ -67,7 +68,7 @@ def extract_date_from_exif(file_path: str) -> Optional[str]:
         from PIL.ExifTags import TAGS
 
         with Image.open(file_path) as img:
-            exif_data = img._getexif()
+            exif_data = img.getexif()
 
             if exif_data:
                 # Try to extract date from DateTime tag
@@ -654,8 +655,7 @@ def bulk_update_batches(confirmed_photos: List[Dict], registry: BatchRegistry, m
 
     if not dry_run:
         try:
-            with open(log_path, "w", encoding="utf-8") as f:
-                json.dump(log_entries, f, indent=2, ensure_ascii=False)
+            save_json_with_backup(log_entries, log_path, indent=2)
             print(f"  ✓ Log saved to: {log_path}")
         except Exception as e:
             print(f"  Warning: Could not save log file: {e}")

--- a/givephotobankreadymediafiles/scripts/add_missing_editorial_tags.py
+++ b/givephotobankreadymediafiles/scripts/add_missing_editorial_tags.py
@@ -1,0 +1,619 @@
+#!/usr/bin/env python3
+"""
+Interactive tool to add missing editorial tags to photos in completed batches.
+
+Scans completed batches for photos with editorial_data.city but missing editorial tag
+in description, shows each photo to user for confirmation, then bulk-updates batch + PhotoMedia.csv.
+
+Usage:
+    python add_missing_editorial_tags.py [--dry-run]
+
+Example:
+    python add_missing_editorial_tags.py --dry-run  # Preview changes without writing
+    python add_missing_editorial_tags.py            # Interactive mode with confirmation
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Set
+
+# Add parent directories to path
+script_dir = Path(__file__).parent  # givephotobankreadymediafiles/scripts/
+module_dir = script_dir.parent  # givephotobankreadymediafiles/
+root_dir = module_dir.parent  # Fotobanking/
+
+# Add both paths:
+# - module_dir for importing givephotobankreadymediafileslib
+# - root_dir for importing shared
+sys.path.insert(0, str(module_dir))
+sys.path.insert(0, str(root_dir))
+
+from givephotobankreadymediafileslib.batch_state import (
+    BatchRegistry,
+    BatchState,
+)
+from givephotobankreadymediafileslib.constants import (
+    BATCH_STATE_DIR,
+    COL_DESCRIPTION,
+    COL_FILE,
+    DEFAULT_MEDIA_CSV_PATH,
+    MAX_DESCRIPTION_LENGTH,
+)
+from shared.file_operations import load_csv, save_csv_with_backup
+from shared.config import get_config
+from givephotobankreadymediafileslib.metadata_generator import create_metadata_generator
+
+
+def extract_date_from_exif(file_path: str) -> Optional[str]:
+    """
+    Extract DateTime from EXIF and format as DD MM YYYY.
+    Uses PIL/Pillow - same method as batch mode.
+
+    Args:
+        file_path: Path to image file
+
+    Returns:
+        Formatted date string "DD MM YYYY" or None if not found
+    """
+    try:
+        if not os.path.exists(file_path):
+            return None
+
+        from PIL import Image
+        from PIL.ExifTags import TAGS
+
+        with Image.open(file_path) as img:
+            exif_data = img._getexif()
+
+            if exif_data:
+                # Try to extract date from DateTime tag
+                for tag_id, value in exif_data.items():
+                    tag = TAGS.get(tag_id, tag_id)
+
+                    if tag == 'DateTime' and value:
+                        try:
+                            # Convert EXIF datetime to DD MM YYYY format
+                            dt = datetime.strptime(value, "%Y:%m:%d %H:%M:%S")
+                            return dt.strftime("%d %m %Y")
+                        except ValueError:
+                            continue
+
+        return None
+
+    except Exception as e:
+        print(f"  Warning: Could not extract EXIF date from {file_path}: {e}")
+        return None
+
+
+def has_editorial_tag(description: str, city: str) -> bool:
+    """
+    Check if description starts with proper editorial tag for given city.
+
+    Args:
+        description: Description text to check
+        city: City name to look for in tag
+
+    Returns:
+        True if description starts with "City, Czech - DD MM YYYY: "
+    """
+    if not description or not city:
+        return False
+
+    # Pattern: CITY, Czech - DD MM YYYY:
+    # Case-insensitive city match
+    pattern = rf"^{re.escape(city)},\s*Czech\s*-\s*\d{{2}}\s+\d{{2}}\s+\d{{4}}:\s*"
+    return re.match(pattern, description, re.IGNORECASE) is not None
+
+
+def scan_completed_batches(registry: BatchRegistry) -> List[Dict]:
+    """
+    Scan completed batches and find photos with editorial_data.city but missing tag.
+    Also finds alternative (edited) versions of those photos.
+
+    Args:
+        registry: Batch registry instance
+
+    Returns:
+        Tuple of (candidates list, cities_found set)
+    """
+    candidates = []
+    completed_batches = registry.data.get("completed_batches", [])
+
+    if not completed_batches:
+        return candidates, set()
+
+    completed_batch_ids = [b["batch_id"] for b in completed_batches]
+
+    print(f"\nScanning {len(completed_batch_ids)} completed batches for editorial photos...")
+
+    cities_found = set()
+
+    for batch_id in completed_batch_ids:
+        try:
+            batch_dir = registry.get_batch_dir(batch_id)
+            if not os.path.exists(batch_dir):
+                continue
+
+            batch_state = BatchState(batch_id, batch_dir)
+            files = batch_state.all_files()
+
+            # First pass: Find originals with editorial_data.city needing tags
+            originals_needing_tags = {}  # file_path -> (city, country, date)
+
+            for file_entry in files:
+                # Skip alternative entries in first pass
+                if file_entry.get("entry_type") == "alternative":
+                    continue
+
+                # Check if photo has editorial_data.city
+                editorial_data = file_entry.get("editorial_data")
+                if not editorial_data or not isinstance(editorial_data, dict):
+                    continue
+
+                city = editorial_data.get("city", "").strip()
+                if not city:
+                    continue
+
+                cities_found.add(city)
+
+                # Get current result
+                result = file_entry.get("result")
+                if not result:
+                    # Batch not completed for this file - skip
+                    continue
+
+                current_description = result.get("description", "")
+
+                # Check if editorial tag is already correct
+                if has_editorial_tag(current_description, city):
+                    continue  # Already has correct tag - skip
+
+                # This photo needs tag correction
+                file_path = file_entry.get("file_path", "")
+                custom_id = file_entry.get("custom_id", "")
+
+                # Extract date from EXIF
+                date = extract_date_from_exif(file_path)
+                if not date:
+                    date = "UNKNOWN"
+
+                # Store original info
+                country = editorial_data.get("country", "Czech")
+                originals_needing_tags[file_path] = (city, country, date)
+
+                # Add original to candidates
+                candidates.append({
+                    "file_path": file_path,
+                    "batch_id": batch_id,
+                    "custom_id": custom_id,
+                    "city": city,
+                    "country": country,
+                    "date": date,
+                    "current_description": current_description,
+                    "current_title": result.get("title", ""),
+                    "is_alternative": False,
+                    "edit_tag": None,
+                })
+
+            # Second pass: Find alternative entries for those originals
+            for file_entry in files:
+                if file_entry.get("entry_type") != "alternative":
+                    continue
+
+                original_path = file_entry.get("original_file_path", "")
+                if not original_path:
+                    continue
+
+                # Check if this alternative's original needs tags
+                if original_path not in originals_needing_tags:
+                    continue
+
+                # Get result for alternative
+                result = file_entry.get("result")
+                if not result:
+                    continue
+
+                city, country, date = originals_needing_tags[original_path]
+
+                current_description = result.get("description", "")
+
+                # Check if editorial tag is already correct for alternative
+                if has_editorial_tag(current_description, city):
+                    continue
+
+                # Add alternative to candidates
+                file_path = file_entry.get("file_path", "")
+                custom_id = file_entry.get("custom_id", "")
+                edit_tag = file_entry.get("edit_tag", "")
+
+                candidates.append({
+                    "file_path": file_path,
+                    "batch_id": batch_id,
+                    "custom_id": custom_id,
+                    "city": city,
+                    "country": country,
+                    "date": date,
+                    "current_description": current_description,
+                    "current_title": result.get("title", ""),
+                    "is_alternative": True,
+                    "edit_tag": edit_tag,
+                    "original_file_path": original_path,
+                })
+
+        except Exception as e:
+            print(f"  Warning: Error scanning batch {batch_id}: {e}")
+            continue
+
+    return candidates, cities_found
+
+
+def interactive_confirmation(candidates: List[Dict], cities_found: Set[str]) -> List[Dict]:
+    """
+    Show each candidate photo to user for confirmation.
+
+    Args:
+        candidates: List of candidate photos
+        cities_found: Set of unique cities found
+
+    Returns:
+        List of confirmed photos
+    """
+    if not candidates:
+        return []
+
+    confirmed = []
+    total = len(candidates)
+
+    # Show detected cities
+    print(f"\n{'='*70}")
+    print(f"Detected {len(cities_found)} unique cities in completed batches:")
+    for city in sorted(cities_found):
+        print(f"  - {city}")
+    print(f"\nFound {total} photos with editorial_data.city but missing proper tag")
+    print(f"{'='*70}\n")
+
+    for i, candidate in enumerate(candidates, 1):
+        print(f"\n{'='*70}")
+        print(f"Photo {i}/{total}:")
+        print(f"  File: {os.path.basename(candidate['file_path'])}")
+
+        # Show if it's an edited version
+        if candidate.get('is_alternative'):
+            edit_tag = candidate.get('edit_tag', '')
+            edit_name = edit_tag.replace('_', '').upper() if edit_tag else 'EDITED'
+            print(f"  Type: {edit_name} version (alternative)")
+            print(f"  Original: {os.path.basename(candidate.get('original_file_path', ''))}")
+        else:
+            print(f"  Type: ORIGINAL")
+
+        print(f"  Batch: {candidate['batch_id']}")
+        print(f"  City (from editorial_data): {candidate['city']}")
+        print(f"  Country: {candidate['country']}")
+        print(f"  Date from EXIF: {candidate['date']}")
+        print(f"\n  Current title: {candidate['current_title']}")
+        print(f"  Current description: {candidate['current_description'][:100]}...")
+
+        editorial_tag = f"{candidate['city']}, {candidate['country']} - {candidate['date']}: "
+        print(f"\n  Editorial tag to ADD: '{editorial_tag}'")
+        print(f"  New description: '{editorial_tag}{candidate['current_description'][:70]}...'")
+
+        while True:
+            response = input("\n  Confirm adding editorial tag? [y/n/skip]: ").strip().lower()
+
+            if response == "y":
+                confirmed.append(candidate)
+                print("  ✓ Confirmed")
+                break
+            elif response == "skip" or response == "n":
+                print("  ⊘ Skipped")
+                break
+            else:
+                print("  Invalid input. Please enter y/n/skip")
+
+    print(f"\n{'='*70}")
+    print(f"Summary: Confirmed {len(confirmed)}/{total} photos")
+
+    return confirmed
+
+
+def regenerate_description_with_ai(photo: Dict, model_key: str) -> Optional[str]:
+    """
+    Regenerate description using AI to fit within character limit with editorial tag.
+
+    Args:
+        photo: Photo dict containing file_path, current_title, current_description, editorial data
+        model_key: AI model key (e.g., "openai/gpt-4o-mini")
+
+    Returns:
+        New description with editorial tag, or None if generation fails
+    """
+    try:
+        file_path = photo["file_path"]
+        title = photo["current_title"]
+        original_description = photo["current_description"]
+
+        # Prepare editorial data for AI generator
+        editorial_data = {
+            "city": photo["city"],
+            "country": photo["country"],
+            "date": photo["date"]
+        }
+
+        # Calculate editorial prefix length
+        editorial_prefix = f"{photo['city']}, {photo['country']} - {photo['date']}: "
+        available_chars = MAX_DESCRIPTION_LENGTH - len(editorial_prefix)
+
+        if available_chars <= 20:
+            print(f"    Warning: Editorial tag too long ({len(editorial_prefix)} chars), not enough space for description")
+            return None
+
+        print(f"    Regenerating description with AI (editorial tag: {len(editorial_prefix)} chars, available: {available_chars} chars)...")
+
+        # Create metadata generator
+        generator = create_metadata_generator(model_key)
+
+        # Generate new description with editorial prefix
+        # AI will automatically handle editorial_data and truncate to fit
+        new_description = generator.generate_description(
+            image_path=file_path,
+            title=title,
+            context=original_description,
+            editorial_data=editorial_data
+        )
+
+        print(f"    ✓ AI generated description: {len(new_description)} chars")
+        return new_description
+
+    except Exception as e:
+        print(f"    Error regenerating description with AI: {e}")
+        return None
+
+
+def bulk_update_batches(confirmed_photos: List[Dict], registry: BatchRegistry, media_csv_path: str, dry_run: bool = False):
+    """
+    Bulk update batch state files and PhotoMedia.csv with editorial tags.
+    Uses AI to regenerate descriptions to fit within character limit.
+
+    Args:
+        confirmed_photos: List of confirmed photos to update
+        registry: Batch registry instance
+        media_csv_path: Path to PhotoMedia.csv
+        dry_run: If True, preview changes without writing
+    """
+    if not confirmed_photos:
+        print("\nNo photos to update.")
+        return
+
+    if dry_run:
+        print(f"\n{'='*70}")
+        print("DRY RUN MODE - No changes will be written")
+        print(f"{'='*70}\n")
+
+    proceed = input(f"\nProceed with updating {len(confirmed_photos)} photos? [y/n]: ").strip().lower()
+
+    if proceed != "y":
+        print("Update cancelled.")
+        return
+
+    # Get AI model from config (use default model like batch mode)
+    print("\nGetting default AI model from config...")
+    try:
+        config = get_config()
+        provider, model = config.get_default_ai_model()
+        if not provider or not model:
+            print("Error: No default AI model configured")
+            return
+        model_key = f"{provider}/{model}"
+        print(f"Using AI model: {model_key}")
+    except Exception as e:
+        print(f"Error getting AI model: {e}")
+        return
+
+    # Group by batch_id for efficient processing
+    photos_by_batch = {}
+    for photo in confirmed_photos:
+        batch_id = photo["batch_id"]
+        if batch_id not in photos_by_batch:
+            photos_by_batch[batch_id] = []
+        photos_by_batch[batch_id].append(photo)
+
+    print(f"\nUpdating {len(confirmed_photos)} photos across {len(photos_by_batch)} batches...")
+    print("=" * 70)
+
+    updated_count = 0
+    log_entries = []
+    total_photos = len(confirmed_photos)
+    current_photo = 0
+
+    for batch_id, photos in photos_by_batch.items():
+        try:
+            batch_dir = registry.get_batch_dir(batch_id)
+            batch_state = BatchState(batch_id, batch_dir)
+            all_files = batch_state.all_files()
+
+            for photo in photos:
+                current_photo += 1
+                custom_id = photo["custom_id"]
+                city = photo["city"]
+                country = photo["country"]
+                date = photo["date"]
+
+                # Find file entry by custom_id
+                file_entry = None
+                for f in all_files:
+                    if f.get("custom_id") == custom_id:
+                        file_entry = f
+                        break
+
+                if not file_entry:
+                    print(f"  Warning: File {custom_id} not found in batch {batch_id}")
+                    continue
+
+                print(f"\n[{current_photo}/{total_photos}] Processing: {os.path.basename(photo['file_path'])}")
+                print(f"  Batch: {batch_id}")
+
+                # Update editorial_data with date
+                if not file_entry.get("editorial_data"):
+                    file_entry["editorial_data"] = {}
+
+                file_entry["editorial_data"]["city"] = city
+                file_entry["editorial_data"]["country"] = country
+                file_entry["editorial_data"]["date"] = date
+                file_entry["editorial"] = True
+
+                # Regenerate description with AI to fit character limit
+                result = file_entry.get("result", {})
+                current_description = result.get("description", "")
+
+                # Use AI to regenerate description with editorial tag
+                new_description = regenerate_description_with_ai(photo, model_key)
+
+                if new_description:
+                    result["description"] = new_description
+                    file_entry["result"] = result
+                else:
+                    # Fallback: just prepend editorial tag (may exceed limit)
+                    print(f"    Warning: AI generation failed, using simple prepend (may exceed {MAX_DESCRIPTION_LENGTH} chars)")
+                    editorial_prefix = f"{city}, {country} - {date}: "
+                    result["description"] = editorial_prefix + current_description
+                    file_entry["result"] = result
+                    new_description = result["description"]
+
+                # Log change
+                log_entries.append({
+                    "timestamp": datetime.now().isoformat(),
+                    "batch_id": batch_id,
+                    "custom_id": custom_id,
+                    "file_path": photo["file_path"],
+                    "city": city,
+                    "country": country,
+                    "date": date,
+                    "editorial_tag": f"{city}, {country} - {date}: ",
+                    "old_description": current_description,
+                    "new_description": new_description,
+                })
+
+                updated_count += 1
+
+            # Save batch state
+            if not dry_run:
+                batch_state.save()
+                print(f"  ✓ Updated batch {batch_id}")
+
+        except Exception as e:
+            print(f"  Error updating batch {batch_id}: {e}")
+            import traceback
+            traceback.print_exc()
+            continue
+
+    # Update PhotoMedia.csv
+    if not dry_run:
+        print("\nUpdating PhotoMedia.csv...")
+        try:
+            # Load CSV
+            records = load_csv(media_csv_path)
+
+            # Update records
+            updates_applied = 0
+            for log_entry in log_entries:
+                file_path = log_entry["file_path"]
+                new_description = log_entry["new_description"]
+
+                for record in records:
+                    record_path = record.get(COL_FILE, "")
+                    if os.path.normpath(record_path).lower() == os.path.normpath(file_path).lower():
+                        record[COL_DESCRIPTION] = new_description
+                        updates_applied += 1
+                        break
+
+            # Save with backup
+            save_csv_with_backup(records, media_csv_path)
+            print(f"  ✓ Applied {updates_applied} updates to PhotoMedia.csv")
+
+        except Exception as e:
+            print(f"  Error updating PhotoMedia.csv: {e}")
+
+    # Save log file
+    timestamp = datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
+    log_filename = f"editorial_tag_additions_{timestamp}.json"
+    log_path = os.path.join(BATCH_STATE_DIR, log_filename)
+
+    if not dry_run:
+        try:
+            with open(log_path, "w", encoding="utf-8") as f:
+                json.dump(log_entries, f, indent=2, ensure_ascii=False)
+            print(f"  ✓ Log saved to: {log_path}")
+        except Exception as e:
+            print(f"  Warning: Could not save log file: {e}")
+
+    print(f"\n{'='*70}")
+    print(f"✓ Updated {updated_count} photos in {len(photos_by_batch)} batches")
+    if dry_run:
+        print("(Dry run - no changes written)")
+    print(f"{'='*70}")
+
+
+def main():
+    """Main entry point for the script."""
+    parser = argparse.ArgumentParser(
+        description="Add missing editorial tags to photos in completed batches",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Preview changes without writing
+  python add_missing_editorial_tags.py --dry-run
+
+  # Interactive mode with confirmation
+  python add_missing_editorial_tags.py
+        """,
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Preview changes without writing to files")
+    parser.add_argument("--media-csv", default=DEFAULT_MEDIA_CSV_PATH, help="Path to PhotoMedia.csv")
+
+    args = parser.parse_args()
+
+    print("=" * 70)
+    print("ADD MISSING EDITORIAL TAGS TO COMPLETED BATCH PHOTOS")
+    print("=" * 70)
+
+    # Load batch registry
+    try:
+        registry = BatchRegistry()
+    except Exception as e:
+        print(f"\nError loading batch registry: {e}")
+        return 1
+
+    # Step 1: Scan completed batches
+    result = scan_completed_batches(registry)
+    if isinstance(result, tuple):
+        candidates, cities_found = result
+    else:
+        candidates = result
+        cities_found = set()
+
+    if not candidates:
+        print("\n✓ No photos found needing editorial tag correction.")
+        print("  All editorial photos in completed batches have proper tags.")
+        return 0
+
+    # Step 2: Interactive confirmation
+    confirmed_photos = interactive_confirmation(candidates, cities_found)
+
+    if not confirmed_photos:
+        print("\nNo photos confirmed for update.")
+        return 0
+
+    # Step 3: Bulk update
+    bulk_update_batches(confirmed_photos, registry, args.media_csv, dry_run=args.dry_run)
+
+    print("\n✓ Done!")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Created new script `add_editorial_tags_to_photomedia.py` for adding missing editorial tags to PhotoMedia.csv
- Script scans completed batches and existing PhotoMedia.csv for editorial cities
- Detects photos missing editorial tags based on city mentions in title/description
- Provides interactive confirmation to avoid false positives
- Uses batch descriptions when available, AI regeneration otherwise

## Key Features
- **Two-source city detection**: Collects cities from both completed batches and existing editorial tags in PhotoMedia.csv
- **Interactive confirmation**: Shows each candidate photo to user for approval before processing
- **Dual processing modes**: 
  - Dry-run mode: Preview all changes without applying
  - Live mode: Interactive confirmation followed by batch/AI processing
- **Proper file path handling**: Uses COL_PATH for full file paths to enable EXIF extraction
- **Progress tracking**: tqdm progress bar for AI generation calls

## Test plan
- [x] Dry-run mode works and shows all candidates
- [x] City detection from both sources (batches + PhotoMedia.csv)
- [x] File path resolution using COL_PATH
- [ ] Interactive confirmation workflow in live mode
- [ ] Batch description application
- [ ] AI description regeneration with editorial tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)