### PR TITLE
Fix Dreamstime category case mismatch (#157)

### DIFF
--- a/givephotobankreadymediafiles/givephotobankreadymediafileslib/batch_manager.py
+++ b/givephotobankreadymediafiles/givephotobankreadymediafileslib/batch_manager.py
@@ -69,13 +69,14 @@ def _validate_dreamstime_categories(
     if not selected or not valid_categories:
         return selected if selected else []
 
-    valid_set = set(valid_categories)
+    valid_lower = {v.lower(): v for v in valid_categories}
     validated = []
 
     for cat in selected:
         cat_str = str(cat).strip()
-        if cat_str in valid_set:
-            validated.append(cat_str)
+        canonical = valid_lower.get(cat_str.lower())
+        if canonical:
+            validated.append(canonical)
         else:
             logging.warning("Invalid Dreamstime category filtered: '%s'", cat_str)
 

--- a/givephotobankreadymediafiles/givephotobankreadymediafileslib/batch_prompts.py
+++ b/givephotobankreadymediafiles/givephotobankreadymediafileslib/batch_prompts.py
@@ -61,7 +61,7 @@ def build_batch_prompt(user_description: str, editorial_data: Optional[Dict[str,
             hierarchy = parse_dreamstime_hierarchy(dreamstime_cats)
             if hierarchy:
                 for main_cat, sub_cats in hierarchy.items():
-                    categories_block += f"{main_cat.upper()}: {', '.join(sub_cats)}\n"
+                    categories_block += f"{main_cat}: {', '.join(sub_cats)}\n"
                 categories_block += "\n"
             else:
                 # Fallback to flat list if parsing fails


### PR DESCRIPTION
## Summary

Fixes #157 — Dreamstime categories were always empty after AI processing because two bugs introduced together in commit `d661b06` (2026-01-19) directly contradicted each other.

- **`batch_prompts.py`**: Removed `.upper()` from category header formatting. The prompt was showing `EDITORIAL: Events, ...` which caused the AI to echo back `EDITORIAL -> Events` — rejected by the validator.
- **`batch_manager._validate_dreamstime_categories`**: Replaced case-sensitive `set` lookup with a `{v.lower(): v}` mapping so that any casing variant of a valid category is accepted and the canonical title-case form is stored.

## Root cause

Both bugs were added in the same commit by DannyJPN. `.upper()` in the prompt and case-sensitive validation directly contradicted each other — result was `validated: N -> 0` for every processed file, Dreamstime categories always empty.

## Test plan

- [ ] Run `givephotobankreadymediafiles` on any batch with Dreamstime categories enabled
- [ ] Verify log shows `Dreamstime categories validated: 3 -> 3` (not `3 -> 0`)
- [ ] Verify Dreamstime kategorie column in PhotoMedia.csv is populated after processing
- [ ] Verify no regression: categories outside PhotoCategories.csv are still filtered with WARNING

🤖 Generated with [Claude Code](https://claude.ai/claude-code)