### PR TITLE
Update AI model lists to 2026-03-24

### DIFF
--- a/givephotobankreadymediafiles/IMPLEMENTATION_STATUS.md
+++ b/givephotobankreadymediafiles/IMPLEMENTATION_STATUS.md
@@ -74,3 +74,4 @@
 - Removed duplicate JSON keys (`claude-3-7-sonnet-20250219`, `claude-3-5-haiku-20241022`) that caused silent data loss
 - Added `claude-opus-4-7` as current flagship Anthropic model
 - Corrected Ollama `vision_models` set: added `qwen2.5-vl`, `minicpm-v`, `moondream2`, `llama4:scout/maverick`
+- Fixed `supports_images` flag in config_template.json for o3/o3-pro/o4-mini (all three support vision)

--- a/givephotobankreadymediafiles/IMPLEMENTATION_STATUS.md
+++ b/givephotobankreadymediafiles/IMPLEMENTATION_STATUS.md
@@ -1,0 +1,76 @@
+# IMPLEMENTATION_STATUS.md — givephotobankreadymediafiles
+
+## What is implemented
+
+### Core pipeline
+- `givephotobankreadymediafiles.py` — main entry point, GUI media viewer with metadata editing
+- `preparemediafile.py` — single-file CLI metadata preparation
+- `generatealternatives.py` — generate BW/negative/sharpen/misty/blurred variants
+
+### AI metadata generation (`givephotobankreadymediafileslib/`)
+- `metadata_generator.py` — title, description, keyword generation via AI providers
+- `ai_coordinator.py` — orchestrates single and batch AI requests
+- `batch_manager.py` — OpenAI Batch API lifecycle (collect → send → poll → import)
+- `batch_state.py`, `batch_lock.py` — batch persistence and concurrency control
+- `batch_prompts.py` — prompt templates for batch metadata generation
+- `categories_manager.py` — per-bank category assignment
+- `alternative_generator.py` — alternative edit type processing
+
+### GUI components (`givephotobankreadymediafileslib/`)
+- `media_viewer.py`, `media_viewer_refactored.py` — main viewer window
+- `media_display.py`, `viewer_state.py` — display helpers and state management
+- `editorial_dialog.py` — editorial metadata input dialog
+- `batch_description_dialog.py` — batch job description dialog
+- `tag_entry.py`, `ui_components.py` — reusable UI widgets
+- `media_processor.py`, `media_helper.py` — file I/O helpers for GUI
+- `metadata_validator.py` — validates metadata before write
+- `mediainfo_loader.py` — loads EXIF/media info
+
+### AI provider layer (`shared/`)
+- `ai_provider.py` — abstract base: `Message`, `AIResponse`, `BatchJob`, `ContentBlock`
+- `cloud_ai.py`, `local_ai.py`, `neural_network.py` — provider base classes
+- `openai_provider.py` — OpenAI API (GPT-4o, GPT-4.1, GPT-5, o-series), batch support
+- `anthropic_provider.py` — Anthropic API (Claude 3.x, Claude 4.x), batch support
+- `ollama_provider.py` — local Ollama server (LLaVA, Llama 3.2-vision, Qwen2.5-VL, etc.)
+- `ai_factory.py` — provider registry and `create_from_model_key()` convenience API
+- `ai_module.py` — high-level wrapper used by metadata_generator
+- `prompt_manager.py` — prompt template management
+
+### Utilities (`shared/`)
+- `config.py` — loads `config_template.json` and user config overlay
+- `config_template.json` — canonical model/provider registry with pricing
+- `exif_handler.py`, `exif_downloader.py` — EXIF read/write via ExifTool
+- `file_operations.py` — centralised CRUD (copy, move, delete, ensure_dir)
+- `hash_utils.py` — perceptual and cryptographic hash helpers
+- `csv_sanitizer.py` — CSV encoding/header normalisation
+- `logging_config.py`, `utils.py` — shared logging and misc helpers
+
+### Constants
+- `givephotobankreadymediafileslib/constants.py` — all default paths, column names, batch
+  limits, status values, Ollama model lists, photobank category counts
+
+### Tests
+- Unit tests for all major modules under `tests/unit/`
+- Integration tests: `tests/integration/test_metadata_generator_pipeline__scenarios.py`
+- Performance tests: `tests/performance/`
+- Security tests: `tests/security/`
+
+---
+
+## Pending / known limitations
+
+- No Google AI (Gemini) or Mistral provider implementations (stubs registered in factory but classes not present)
+- `uploadtophotobanks/` integration is planned but not connected
+- Batch polling uses fixed interval; adaptive back-off not implemented
+- Ollama vision model list in `ollama_provider.py` is a static set; no auto-discovery from running server at init time
+- `config_template.json` prices are indicative; no live price-fetch mechanism
+
+---
+
+## Recent changes
+
+- AI provider model lists updated to reflect current Claude 4.x, GPT-5/4.1, and Ollama vision models
+- Fixed pricing errors across OpenAI and Anthropic entries in `config_template.json`
+- Removed duplicate JSON keys (`claude-3-7-sonnet-20250219`, `claude-3-5-haiku-20241022`) that caused silent data loss
+- Added `claude-opus-4-7` as current flagship Anthropic model
+- Corrected Ollama `vision_models` set: added `qwen2.5-vl`, `minicpm-v`, `moondream2`, `llama4:scout/maverick`

--- a/givephotobankreadymediafiles/givephotobankreadymediafileslib/constants.py
+++ b/givephotobankreadymediafiles/givephotobankreadymediafileslib/constants.py
@@ -167,7 +167,16 @@ DEFAULT_OLLAMA_MODELS = [
     "bakllava:7b",
     "llama3.2-vision:11b",
     "llama3.2-vision:90b",
-    "cogvlm:17b"
+    "cogvlm:17b",
+    # Added 2026-03-24
+    "gemma3:12b",
+    "gemma3:27b",
+    "qwen2.5-vl:7b",
+    "qwen2.5-vl:72b",
+    "llama4:scout",
+    "llama4:maverick",
+    "minicpm-v:8b",
+    "moondream2",
 ]
 
 DEFAULT_OLLAMA_VISION_MODEL = "llava:7b-v1.6"

--- a/givephotobankreadymediafiles/givephotobankreadymediafileslib/constants.py
+++ b/givephotobankreadymediafiles/givephotobankreadymediafileslib/constants.py
@@ -168,7 +168,6 @@ DEFAULT_OLLAMA_MODELS = [
     "llama3.2-vision:11b",
     "llama3.2-vision:90b",
     "cogvlm:17b",
-    # Added 2026-03-24
     "gemma3:12b",
     "gemma3:27b",
     "qwen2.5-vl:7b",

--- a/givephotobankreadymediafiles/shared/ai_factory.py
+++ b/givephotobankreadymediafiles/shared/ai_factory.py
@@ -218,23 +218,75 @@ class AIFactory:
         
         models = {
             ProviderType.OPENAI: [
-                'gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo', 'gpt-3.5-turbo'
+                # GPT-5.4 Series (2026)
+                'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.4-nano',
+                # GPT-5 Series (2025)
+                'gpt-5', 'gpt-5-mini', 'gpt-5-nano',
+                # GPT-4.1 Series (2025)
+                'gpt-4.1', 'gpt-4.1-mini', 'gpt-4.1-nano',
+                'gpt-4.1-2025-04-14', 'gpt-4.1-mini-2025-04-14', 'gpt-4.1-nano-2025-04-14',
+                # GPT-4o Series
+                'gpt-4o', 'gpt-4o-mini', 'gpt-4o-2024-11-20', 'gpt-4o-2024-08-06', 'gpt-4o-mini-2024-07-18',
+                # Reasoning
+                'o1', 'o1-mini', 'o1-pro', 'o1-2024-12-17',
+                'o3', 'o3-mini', 'o3-pro', 'o3-2025-04-16',
+                'o4-mini', 'o4-mini-2025-04-16',
+                # Legacy
+                'gpt-4-turbo', 'gpt-4-turbo-2024-04-09', 'gpt-3.5-turbo',
             ],
             ProviderType.ANTHROPIC: [
+                # Added 2026-03-24
+                'claude-opus-4-6', 'claude-sonnet-4-6', 'claude-haiku-4-5-20251001',
+                'claude-sonnet-4-5-20250929', 'claude-opus-4-5-20251101',
+                'claude-opus-4-1-20250805',
+                'claude-sonnet-4-20250514', 'claude-opus-4-20250514',
+                'claude-3-7-sonnet-20250219', 'claude-3-5-haiku-20241022',
+                # Legacy
                 'claude-3-5-sonnet-20241022', 'claude-3-opus-20240229',
-                'claude-3-sonnet-20240229', 'claude-3-haiku-20240307'
+                'claude-3-sonnet-20240229', 'claude-3-haiku-20240307',
             ],
             ProviderType.GOOGLE: [
-                'gemini-pro', 'gemini-pro-vision', 'gemini-ultra'
+                # Gemini 3 Series (2026)
+                'gemini-3.1-pro-preview', 'gemini-3-flash-preview', 'gemini-3.1-flash-lite-preview',
+                # Gemini 2.5 Series
+                'gemini-2.5-pro', 'gemini-2.5-pro-exp-03-25',
+                'gemini-2.5-flash', 'gemini-2.5-flash-lite',
+                'gemini-2.5-flash-preview-09-2025',
+                # Gemini 2.0 Series
+                'gemini-2.0-flash', 'gemini-2.0-flash-001',
+                'gemini-2.0-flash-lite', 'gemini-2.0-flash-lite-001',
+                # Gemini 1.5 Series
+                'gemini-1.5-pro', 'gemini-1.5-pro-002',
+                'gemini-1.5-flash', 'gemini-1.5-flash-002',
+                'gemini-1.5-flash-8b', 'gemini-1.5-flash-8b-001',
+                # Legacy
+                'gemini-pro', 'gemini-pro-vision', 'gemini-ultra',
             ],
             ProviderType.MISTRAL: [
-                'mistral-large-latest', 'mistral-medium-latest', 'mistral-small-latest'
+                # Frontier models
+                'mistral-large-3-25-12', 'mistral-medium-3-1-25-08',
+                'pixtral-large-24-11',
+                # Reasoning models
+                'magistral-medium-1-2-25-09', 'magistral-small-1-2-25-09',
+                # Small/efficient models
+                'mistral-small-4-0-26-03', 'mistral-small-3-2-25-06',
+                # Edge/on-device models
+                'ministral-3-14b-25-12', 'ministral-3-8b-25-12', 'ministral-3-3b-25-12',
+                # Code models
+                'devstral-2-25-12', 'devstral-small-2-25-12', 'codestral-2508',
+                # Legacy aliases
+                'mistral-large-latest', 'mistral-medium-latest', 'mistral-small-latest',
             ],
             ProviderType.OLLAMA: [
                 'llava:7b', 'llava:13b', 'llava:34b', 'llava:7b-v1.6',
                 'bakllava:7b', 'llama3.2-vision:11b', 'llama3.2:3b',
-                'mistral:7b', 'codellama:13b'
-            ]
+                'mistral:7b', 'codellama:13b',
+                # Added 2026-03-24
+                'gemma3:12b', 'gemma3:27b',
+                'qwen2.5-vl:7b', 'qwen2.5-vl:72b',
+                'llama4:scout', 'llama4:maverick',
+                'minicpm-v:8b', 'moondream2',
+            ],
         }
 
         return models.get(provider_type, [])

--- a/givephotobankreadymediafiles/shared/ai_factory.py
+++ b/givephotobankreadymediafiles/shared/ai_factory.py
@@ -235,13 +235,14 @@ class AIFactory:
                 'gpt-4-turbo', 'gpt-4-turbo-2024-04-09', 'gpt-3.5-turbo',
             ],
             ProviderType.ANTHROPIC: [
-                # Added 2026-03-24
-                'claude-opus-4-6', 'claude-sonnet-4-6', 'claude-haiku-4-5-20251001',
+                # Current
+                'claude-opus-4-7', 'claude-sonnet-4-6', 'claude-haiku-4-5-20251001',
+                # Legacy
+                'claude-opus-4-6',
                 'claude-sonnet-4-5-20250929', 'claude-opus-4-5-20251101',
                 'claude-opus-4-1-20250805',
                 'claude-sonnet-4-20250514', 'claude-opus-4-20250514',
                 'claude-3-7-sonnet-20250219', 'claude-3-5-haiku-20241022',
-                # Legacy
                 'claude-3-5-sonnet-20241022', 'claude-3-opus-20240229',
                 'claude-3-sonnet-20240229', 'claude-3-haiku-20240307',
             ],
@@ -281,7 +282,6 @@ class AIFactory:
                 'llava:7b', 'llava:13b', 'llava:34b', 'llava:7b-v1.6',
                 'bakllava:7b', 'llama3.2-vision:11b', 'llama3.2:3b',
                 'mistral:7b', 'codellama:13b',
-                # Added 2026-03-24
                 'gemma3:12b', 'gemma3:27b',
                 'qwen2.5-vl:7b', 'qwen2.5-vl:72b',
                 'llama4:scout', 'llama4:maverick',

--- a/givephotobankreadymediafiles/shared/anthropic_provider.py
+++ b/givephotobankreadymediafiles/shared/anthropic_provider.py
@@ -36,31 +36,63 @@ class AnthropicProvider(CloudAIProvider):
         """
         super().__init__(model_name, **kwargs)
 
-        # Model capabilities
+        # Model capabilities - Updated 2026-03-24
         self._vision_models = {
             'claude-3-opus-20240229', 'claude-3-sonnet-20240229', 'claude-3-haiku-20240307',
-            'claude-3-5-sonnet-20241022', 'claude-3-5-sonnet-20240620', 
-            'claude-4', 'claude-opus-4', 'claude-sonnet-4'
+            'claude-3-5-sonnet-20241022', 'claude-3-5-sonnet-20240620',
+            'claude-4', 'claude-opus-4', 'claude-sonnet-4',
+            # Added 2026-03-24
+            'claude-opus-4-6', 'claude-sonnet-4-6',
+            'claude-haiku-4-5-20251001', 'claude-haiku-4-5',
+            'claude-sonnet-4-5-20250929', 'claude-sonnet-4-5',
+            'claude-opus-4-5-20251101', 'claude-opus-4-5',
+            'claude-opus-4-1-20250805', 'claude-opus-4-1',
+            'claude-sonnet-4-20250514', 'claude-sonnet-4-0',
+            'claude-opus-4-20250514', 'claude-opus-4-0',
+            'claude-3-7-sonnet-20250219',
+            'claude-3-5-haiku-20241022',
         }
-        
+
         # Context windows
         self._context_limits = {
             'claude-3-haiku-20240307': 200_000,
-            'claude-3-sonnet-20240229': 200_000, 
+            'claude-3-sonnet-20240229': 200_000,
             'claude-3-opus-20240229': 200_000,
             'claude-3-5-sonnet-20241022': 200_000,
             'claude-3-5-sonnet-20240620': 200_000,
-            'claude-sonnet-4': 1_000_000,  # Beta 1M context
-            'claude-opus-4': 200_000
+            'claude-sonnet-4': 1_000_000,
+            'claude-opus-4': 200_000,
+            # Added 2026-03-24
+            'claude-opus-4-6': 200_000,
+            'claude-sonnet-4-6': 200_000,
+            'claude-haiku-4-5-20251001': 200_000,
+            'claude-sonnet-4-5-20250929': 200_000,
+            'claude-opus-4-5-20251101': 200_000,
+            'claude-opus-4-1-20250805': 200_000,
+            'claude-sonnet-4-20250514': 200_000,
+            'claude-opus-4-20250514': 200_000,
+            'claude-3-7-sonnet-20250219': 200_000,
+            'claude-3-5-haiku-20241022': 200_000,
         }
-        
-        # Pricing (per 1K tokens, as of 2025)
+
+        # Pricing (per 1K tokens, as of 2026-03-24)
         self._pricing = {
             'claude-3-haiku-20240307': {'input': 0.00025, 'output': 0.00125},
             'claude-3-sonnet-20240229': {'input': 0.003, 'output': 0.015},
             'claude-3-opus-20240229': {'input': 0.015, 'output': 0.075},
             'claude-3-5-sonnet-20241022': {'input': 0.003, 'output': 0.015},
             'claude-3-5-sonnet-20240620': {'input': 0.003, 'output': 0.015},
+            # Added 2026-03-24
+            'claude-3-5-haiku-20241022': {'input': 0.0008, 'output': 0.004},
+            'claude-3-7-sonnet-20250219': {'input': 0.003, 'output': 0.015},
+            'claude-sonnet-4-20250514': {'input': 0.003, 'output': 0.015},
+            'claude-opus-4-20250514': {'input': 0.015, 'output': 0.075},
+            'claude-opus-4-1-20250805': {'input': 0.015, 'output': 0.075},
+            'claude-sonnet-4-5-20250929': {'input': 0.003, 'output': 0.015},
+            'claude-opus-4-5-20251101': {'input': 0.015, 'output': 0.075},
+            'claude-haiku-4-5-20251001': {'input': 0.0008, 'output': 0.004},
+            'claude-sonnet-4-6': {'input': 0.003, 'output': 0.015},
+            'claude-opus-4-6': {'input': 0.015, 'output': 0.075},
         }
         
         # Initialize client

--- a/givephotobankreadymediafiles/shared/anthropic_provider.py
+++ b/givephotobankreadymediafiles/shared/anthropic_provider.py
@@ -36,12 +36,11 @@ class AnthropicProvider(CloudAIProvider):
         """
         super().__init__(model_name, **kwargs)
 
-        # Model capabilities - Updated 2026-03-24
         self._vision_models = {
             'claude-3-opus-20240229', 'claude-3-sonnet-20240229', 'claude-3-haiku-20240307',
             'claude-3-5-sonnet-20241022', 'claude-3-5-sonnet-20240620',
             'claude-4', 'claude-opus-4', 'claude-sonnet-4',
-            # Added 2026-03-24
+            'claude-opus-4-7',
             'claude-opus-4-6', 'claude-sonnet-4-6',
             'claude-haiku-4-5-20251001', 'claude-haiku-4-5',
             'claude-sonnet-4-5-20250929', 'claude-sonnet-4-5',
@@ -62,37 +61,48 @@ class AnthropicProvider(CloudAIProvider):
             'claude-3-5-sonnet-20240620': 200_000,
             'claude-sonnet-4': 1_000_000,
             'claude-opus-4': 200_000,
-            # Added 2026-03-24
-            'claude-opus-4-6': 200_000,
-            'claude-sonnet-4-6': 200_000,
+            'claude-opus-4-7': 1_000_000,
+            'claude-opus-4-6': 1_000_000,
+            'claude-sonnet-4-6': 1_000_000,
             'claude-haiku-4-5-20251001': 200_000,
+            'claude-haiku-4-5': 200_000,
             'claude-sonnet-4-5-20250929': 200_000,
+            'claude-sonnet-4-5': 200_000,
             'claude-opus-4-5-20251101': 200_000,
+            'claude-opus-4-5': 200_000,
             'claude-opus-4-1-20250805': 200_000,
+            'claude-opus-4-1': 200_000,
             'claude-sonnet-4-20250514': 200_000,
+            'claude-sonnet-4-0': 200_000,
             'claude-opus-4-20250514': 200_000,
+            'claude-opus-4-0': 200_000,
             'claude-3-7-sonnet-20250219': 200_000,
             'claude-3-5-haiku-20241022': 200_000,
         }
 
-        # Pricing (per 1K tokens, as of 2026-03-24)
         self._pricing = {
             'claude-3-haiku-20240307': {'input': 0.00025, 'output': 0.00125},
             'claude-3-sonnet-20240229': {'input': 0.003, 'output': 0.015},
             'claude-3-opus-20240229': {'input': 0.015, 'output': 0.075},
             'claude-3-5-sonnet-20241022': {'input': 0.003, 'output': 0.015},
             'claude-3-5-sonnet-20240620': {'input': 0.003, 'output': 0.015},
-            # Added 2026-03-24
             'claude-3-5-haiku-20241022': {'input': 0.0008, 'output': 0.004},
             'claude-3-7-sonnet-20250219': {'input': 0.003, 'output': 0.015},
             'claude-sonnet-4-20250514': {'input': 0.003, 'output': 0.015},
+            'claude-sonnet-4-0': {'input': 0.003, 'output': 0.015},
             'claude-opus-4-20250514': {'input': 0.015, 'output': 0.075},
+            'claude-opus-4-0': {'input': 0.015, 'output': 0.075},
             'claude-opus-4-1-20250805': {'input': 0.015, 'output': 0.075},
+            'claude-opus-4-1': {'input': 0.015, 'output': 0.075},
             'claude-sonnet-4-5-20250929': {'input': 0.003, 'output': 0.015},
-            'claude-opus-4-5-20251101': {'input': 0.015, 'output': 0.075},
-            'claude-haiku-4-5-20251001': {'input': 0.0008, 'output': 0.004},
+            'claude-sonnet-4-5': {'input': 0.003, 'output': 0.015},
+            'claude-opus-4-5-20251101': {'input': 0.005, 'output': 0.025},
+            'claude-opus-4-5': {'input': 0.005, 'output': 0.025},
+            'claude-haiku-4-5-20251001': {'input': 0.001, 'output': 0.005},
+            'claude-haiku-4-5': {'input': 0.001, 'output': 0.005},
             'claude-sonnet-4-6': {'input': 0.003, 'output': 0.015},
-            'claude-opus-4-6': {'input': 0.015, 'output': 0.075},
+            'claude-opus-4-6': {'input': 0.005, 'output': 0.025},
+            'claude-opus-4-7': {'input': 0.005, 'output': 0.025},
         }
         
         # Initialize client

--- a/givephotobankreadymediafiles/shared/config_template.json
+++ b/givephotobankreadymediafiles/shared/config_template.json
@@ -45,7 +45,7 @@
           "name": "GPT-4o Mini",
           "max_tokens": 4000,
           "supports_images": true,
-          "cost_per_1k_tokens": 0.0015,
+          "cost_per_1k_tokens": 0.00015,
           "notes": "Cost-efficient vision model"
         },
         "o1": {
@@ -126,12 +126,19 @@
       "api_key_env": "ANTHROPIC_API_KEY", 
       "endpoint": "https://api.anthropic.com/v1",
       "models": {
+        "claude-opus-4-7": {
+          "name": "Claude Opus 4.7",
+          "max_tokens": 8000,
+          "supports_images": true,
+          "cost_per_1k_tokens": 0.005,
+          "notes": "Current flagship model"
+        },
         "claude-opus-4-6": {
           "name": "Claude Opus 4.6",
           "max_tokens": 8000,
           "supports_images": true,
-          "cost_per_1k_tokens": 0.015,
-          "notes": "Latest flagship model"
+          "cost_per_1k_tokens": 0.005,
+          "notes": "Legacy flagship model"
         },
         "claude-sonnet-4-6": {
           "name": "Claude Sonnet 4.6",
@@ -144,7 +151,7 @@
           "name": "Claude Haiku 4.5",
           "max_tokens": 8000,
           "supports_images": true,
-          "cost_per_1k_tokens": 0.0008,
+          "cost_per_1k_tokens": 0.001,
           "notes": "Fastest and most affordable"
         },
         "claude-sonnet-4-5-20250929": {
@@ -158,8 +165,29 @@
           "name": "Claude Opus 4.5",
           "max_tokens": 8000,
           "supports_images": true,
-          "cost_per_1k_tokens": 0.015,
+          "cost_per_1k_tokens": 0.005,
           "notes": "Flagship with extended thinking"
+        },
+        "claude-opus-4-1-20250805": {
+          "name": "Claude Opus 4.1",
+          "max_tokens": 8000,
+          "supports_images": true,
+          "cost_per_1k_tokens": 0.015,
+          "notes": "Superior reasoning"
+        },
+        "claude-opus-4-20250514": {
+          "name": "Claude Opus 4",
+          "max_tokens": 8000,
+          "supports_images": true,
+          "cost_per_1k_tokens": 0.015,
+          "notes": "Best coding model, SWE-bench leader"
+        },
+        "claude-sonnet-4-20250514": {
+          "name": "Claude Sonnet 4",
+          "max_tokens": 8000,
+          "supports_images": true,
+          "cost_per_1k_tokens": 0.003,
+          "notes": "High-performance, balanced reasoning"
         },
         "claude-3-7-sonnet-20250219": {
           "name": "Claude Sonnet 3.7",
@@ -173,48 +201,13 @@
           "max_tokens": 8000,
           "supports_images": true,
           "cost_per_1k_tokens": 0.0008,
-          "notes": "Fast and intelligent"
-        },
-        "claude-opus-4-1-20250805": {
-          "name": "Claude Opus 4.1",
-          "max_tokens": 8000,
-          "supports_images": true,
-          "cost_per_1k_tokens": 0.09,
-          "notes": "Latest flagship model, superior reasoning"
-        },
-        "claude-opus-4-20250514": {
-          "name": "Claude Opus 4",
-          "max_tokens": 8000,
-          "supports_images": true,
-          "cost_per_1k_tokens": 0.09,
-          "notes": "Best coding model, SWE-bench leader"
-        },
-        "claude-sonnet-4-20250514": {
-          "name": "Claude Sonnet 4",
-          "max_tokens": 8000,
-          "supports_images": true,
-          "cost_per_1k_tokens": 0.018,
-          "notes": "High-performance, balanced reasoning"
-        },
-        "claude-3-7-sonnet-20250219": {
-          "name": "Claude Sonnet 3.7",
-          "max_tokens": 8000,
-          "supports_images": true,
-          "cost_per_1k_tokens": 0.018,
-          "notes": "Extended thinking capability"
-        },
-        "claude-3-5-haiku-20241022": {
-          "name": "Claude Haiku 3.5",
-          "max_tokens": 8000,
-          "supports_images": true,
-          "cost_per_1k_tokens": 0.0024,
           "notes": "Fastest model, intelligent"
         },
         "claude-3-haiku-20240307": {
           "name": "Claude Haiku 3",
           "max_tokens": 4000,
           "supports_images": true,
-          "cost_per_1k_tokens": 0.00125,
+          "cost_per_1k_tokens": 0.00025,
           "notes": "Quick, compact model"
         }
       }

--- a/givephotobankreadymediafiles/shared/config_template.json
+++ b/givephotobankreadymediafiles/shared/config_template.json
@@ -34,6 +34,48 @@
           "cost_per_1k_tokens": 0.02,
           "notes": "Improved coding and instruction following"
         },
+        "gpt-4.1-mini": {
+          "name": "GPT-4.1 Mini",
+          "max_tokens": 4000,
+          "supports_images": true,
+          "cost_per_1k_tokens": 0.004,
+          "notes": "Balanced performance and cost"
+        },
+        "gpt-4o-mini": {
+          "name": "GPT-4o Mini",
+          "max_tokens": 4000,
+          "supports_images": true,
+          "cost_per_1k_tokens": 0.0015,
+          "notes": "Cost-efficient vision model"
+        },
+        "o1": {
+          "name": "OpenAI o1",
+          "max_tokens": 4000,
+          "supports_images": true,
+          "cost_per_1k_tokens": 0.015,
+          "notes": "Reasoning model with vision support"
+        },
+        "o1-mini": {
+          "name": "OpenAI o1 Mini",
+          "max_tokens": 4000,
+          "supports_images": false,
+          "cost_per_1k_tokens": 0.003,
+          "notes": "Fast reasoning, text only"
+        },
+        "o1-pro": {
+          "name": "OpenAI o1 Pro",
+          "max_tokens": 4000,
+          "supports_images": true,
+          "cost_per_1k_tokens": 0.15,
+          "notes": "Premium reasoning with vision"
+        },
+        "o3-mini": {
+          "name": "OpenAI o3 Mini",
+          "max_tokens": 4000,
+          "supports_images": false,
+          "cost_per_1k_tokens": 0.002,
+          "notes": "Cost-efficient reasoning, text only"
+        },
         "gpt-4.1-nano": {
           "name": "GPT-4.1 Nano",
           "max_tokens": 1000000,
@@ -84,6 +126,55 @@
       "api_key_env": "ANTHROPIC_API_KEY", 
       "endpoint": "https://api.anthropic.com/v1",
       "models": {
+        "claude-opus-4-6": {
+          "name": "Claude Opus 4.6",
+          "max_tokens": 8000,
+          "supports_images": true,
+          "cost_per_1k_tokens": 0.015,
+          "notes": "Latest flagship model"
+        },
+        "claude-sonnet-4-6": {
+          "name": "Claude Sonnet 4.6",
+          "max_tokens": 8000,
+          "supports_images": true,
+          "cost_per_1k_tokens": 0.003,
+          "notes": "Latest balanced model"
+        },
+        "claude-haiku-4-5-20251001": {
+          "name": "Claude Haiku 4.5",
+          "max_tokens": 8000,
+          "supports_images": true,
+          "cost_per_1k_tokens": 0.0008,
+          "notes": "Fastest and most affordable"
+        },
+        "claude-sonnet-4-5-20250929": {
+          "name": "Claude Sonnet 4.5",
+          "max_tokens": 8000,
+          "supports_images": true,
+          "cost_per_1k_tokens": 0.003,
+          "notes": "High performance with extended thinking"
+        },
+        "claude-opus-4-5-20251101": {
+          "name": "Claude Opus 4.5",
+          "max_tokens": 8000,
+          "supports_images": true,
+          "cost_per_1k_tokens": 0.015,
+          "notes": "Flagship with extended thinking"
+        },
+        "claude-3-7-sonnet-20250219": {
+          "name": "Claude Sonnet 3.7",
+          "max_tokens": 8000,
+          "supports_images": true,
+          "cost_per_1k_tokens": 0.003,
+          "notes": "Extended thinking capability"
+        },
+        "claude-3-5-haiku-20241022": {
+          "name": "Claude Haiku 3.5",
+          "max_tokens": 8000,
+          "supports_images": true,
+          "cost_per_1k_tokens": 0.0008,
+          "notes": "Fast and intelligent"
+        },
         "claude-opus-4-1-20250805": {
           "name": "Claude Opus 4.1",
           "max_tokens": 8000,

--- a/givephotobankreadymediafiles/shared/config_template.json
+++ b/givephotobankreadymediafiles/shared/config_template.json
@@ -100,23 +100,23 @@
         "o3": {
           "name": "OpenAI o3",
           "max_tokens": 4000,
-          "supports_images": false,
+          "supports_images": true,
           "cost_per_1k_tokens": 0.05,
-          "notes": "Reasoning model, thinks before responding"
+          "notes": "Reasoning model with vision support"
         },
         "o3-pro": {
           "name": "OpenAI o3 Pro",
           "max_tokens": 4000,
-          "supports_images": false,
+          "supports_images": true,
           "cost_per_1k_tokens": 0.1,
-          "notes": "Premium reasoning model"
+          "notes": "Premium reasoning with vision"
         },
         "o4-mini": {
           "name": "OpenAI o4 Mini",
           "max_tokens": 2000,
-          "supports_images": false,
+          "supports_images": true,
           "cost_per_1k_tokens": 0.02,
-          "notes": "Cost-efficient reasoning"
+          "notes": "Cost-efficient reasoning with vision"
         }
       }
     },

--- a/givephotobankreadymediafiles/shared/ollama_provider.py
+++ b/givephotobankreadymediafiles/shared/ollama_provider.py
@@ -57,7 +57,11 @@ class OllamaProvider(LocalAIProvider):
             'llava:7b-v1.6', 'llava:13b-v1.6', 'llava:34b-v1.6',
             'bakllava', 'bakllava:7b',
             'cogvlm', 'cogvlm:17b',
-            'llama3.2-vision', 'llama3.2-vision:11b', 'llama3.2-vision:90b'
+            'llama3.2-vision', 'llama3.2-vision:11b', 'llama3.2-vision:90b',
+            'qwen2.5-vl:7b', 'qwen2.5-vl:72b',
+            'minicpm-v', 'minicpm-v:8b',
+            'moondream2',
+            'llama4:scout', 'llama4:maverick',
         }
 
         self.session = requests.Session()

--- a/givephotobankreadymediafiles/shared/openai_provider.py
+++ b/givephotobankreadymediafiles/shared/openai_provider.py
@@ -42,7 +42,6 @@ class OpenAIProvider(CloudAIProvider):
         self.organization = kwargs.get('organization')
         self.project = kwargs.get('project')
         
-        # Model capabilities - Updated 2026-03-24
         self._vision_models = {
             # GPT-5.4 Series (2026)
             'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.4-2026-03-05',
@@ -50,7 +49,7 @@ class OpenAIProvider(CloudAIProvider):
             'gpt-5', 'gpt-5-mini', 'gpt-5-2025-08-07', 'gpt-5-mini-2025-08-07',
             # GPT-4.1 Series (2025)
             'gpt-4.1', 'gpt-4.1-mini',
-            'gpt-4.1-2025-04-14', 'gpt-4.1-mini-2025-04-14', 'gpt-4.1-nano-2025-04-14',
+            'gpt-4.1-2025-04-14', 'gpt-4.1-mini-2025-04-14',
             # GPT-4o Series
             'gpt-4-vision-preview', 'gpt-4o', 'gpt-4o-mini',
             'gpt-4o-2024-11-20', 'gpt-4o-2024-08-06', 'gpt-4o-2024-05-13',
@@ -65,12 +64,11 @@ class OpenAIProvider(CloudAIProvider):
         # Non-vision models (text-only)
         self._text_only_models = {
             'gpt-5-nano', 'gpt-5-nano-2025-08-07', 'gpt-5.4-nano',
-            'gpt-4.1-nano',
+            'gpt-4.1-nano', 'gpt-4.1-nano-2025-04-14',
             'o1-mini', 'o1-mini-2024-09-12',
             'o3-mini', 'o3-mini-2025-01-31',
         }
 
-        # Pricing (per 1K tokens, as of 2026-03-24)
         self._pricing = {
             # GPT-5.4 Series (2026)
             'gpt-5.4': {'input': 1.25, 'output': 10.0},
@@ -86,7 +84,7 @@ class OpenAIProvider(CloudAIProvider):
             'gpt-4.1-nano': {'input': 0.003, 'output': 0.01},
             # GPT-4o Series
             'gpt-4o': {'input': 0.005, 'output': 0.015},
-            'gpt-4o-mini': {'input': 0.0015, 'output': 0.0006},
+            'gpt-4o-mini': {'input': 0.00015, 'output': 0.0006},
             'gpt-4-turbo': {'input': 0.01, 'output': 0.03},
             # Reasoning models
             'o1': {'input': 0.015, 'output': 0.060},

--- a/givephotobankreadymediafiles/shared/openai_provider.py
+++ b/givephotobankreadymediafiles/shared/openai_provider.py
@@ -42,34 +42,58 @@ class OpenAIProvider(CloudAIProvider):
         self.organization = kwargs.get('organization')
         self.project = kwargs.get('project')
         
-        # Model capabilities - Updated for 2025
+        # Model capabilities - Updated 2026-03-24
         self._vision_models = {
+            # GPT-5.4 Series (2026)
+            'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.4-2026-03-05',
             # GPT-5 Series (2025)
-            'gpt-5', 'gpt-5-mini',
-            # Legacy models with vision
-            'gpt-4-vision-preview', 'gpt-4o', 'gpt-4o-mini', 
-            'gpt-4-turbo', 'gpt-4-turbo-2024-04-09', 'gpt-4.1'
+            'gpt-5', 'gpt-5-mini', 'gpt-5-2025-08-07', 'gpt-5-mini-2025-08-07',
+            # GPT-4.1 Series (2025)
+            'gpt-4.1', 'gpt-4.1-mini',
+            'gpt-4.1-2025-04-14', 'gpt-4.1-mini-2025-04-14', 'gpt-4.1-nano-2025-04-14',
+            # GPT-4o Series
+            'gpt-4-vision-preview', 'gpt-4o', 'gpt-4o-mini',
+            'gpt-4o-2024-11-20', 'gpt-4o-2024-08-06', 'gpt-4o-2024-05-13',
+            'gpt-4o-mini-2024-07-18',
+            'gpt-4-turbo', 'gpt-4-turbo-2024-04-09',
+            # Reasoning models with vision
+            'o1', 'o1-pro', 'o1-2024-12-17',
+            'o3', 'o3-pro', 'o3-2025-04-16',
+            'o4-mini', 'o4-mini-2025-04-16',
         }
-        
+
         # Non-vision models (text-only)
         self._text_only_models = {
-            'gpt-5-nano', 'gpt-4.1-nano', 'o3', 'o3-pro', 'o4-mini'
+            'gpt-5-nano', 'gpt-5-nano-2025-08-07', 'gpt-5.4-nano',
+            'gpt-4.1-nano',
+            'o1-mini', 'o1-mini-2024-09-12',
+            'o3-mini', 'o3-mini-2025-01-31',
         }
-        
-        # Pricing (per 1K tokens, as of 2025) - Updated from web research
+
+        # Pricing (per 1K tokens, as of 2026-03-24)
         self._pricing = {
-            # GPT-5 Series
+            # GPT-5.4 Series (2026)
+            'gpt-5.4': {'input': 1.25, 'output': 10.0},
+            'gpt-5.4-mini': {'input': 0.01, 'output': 0.03},
+            'gpt-5.4-nano': {'input': 0.005, 'output': 0.02},
+            # GPT-5 Series (2025)
             'gpt-5': {'input': 1.25, 'output': 10.0},
             'gpt-5-mini': {'input': 0.01, 'output': 0.03},
             'gpt-5-nano': {'input': 0.005, 'output': 0.02},
-            # GPT-4 Series  
+            # GPT-4.1 Series
             'gpt-4.1': {'input': 0.02, 'output': 0.06},
+            'gpt-4.1-mini': {'input': 0.004, 'output': 0.016},
             'gpt-4.1-nano': {'input': 0.003, 'output': 0.01},
+            # GPT-4o Series
             'gpt-4o': {'input': 0.005, 'output': 0.015},
             'gpt-4o-mini': {'input': 0.0015, 'output': 0.0006},
             'gpt-4-turbo': {'input': 0.01, 'output': 0.03},
             # Reasoning models
+            'o1': {'input': 0.015, 'output': 0.060},
+            'o1-mini': {'input': 0.003, 'output': 0.012},
+            'o1-pro': {'input': 0.150, 'output': 0.600},
             'o3': {'input': 0.05, 'output': 0.20},
+            'o3-mini': {'input': 0.002, 'output': 0.008},
             'o3-pro': {'input': 0.10, 'output': 0.40},
             'o4-mini': {'input': 0.02, 'output': 0.08},
             # Legacy


### PR DESCRIPTION
## Summary

- **OpenAI**: add GPT-5.4 series, GPT-4.1-mini, dated snapshots, o1/o1-mini/o1-pro/o3-mini/o3-pro reasoning models with correct vision flags and pricing
- **Anthropic**: add claude-opus/sonnet-4-6, claude-haiku-4-5, claude-4-5/4-1 series, claude-3-7-sonnet, claude-3-5-haiku — vision capabilities, context limits and pricing for all
- **Google**: add Gemini 3.x previews, Gemini 2.5/2.0 versioned IDs, Gemini 1.5 series
- **Mistral**: add mistral-medium-3-1, magistral series, ministral-3 series, devstral, codestral
- **Ollama**: add gemma3, qwen2.5-vl, llama4, minicpm-v, moondream2
- **config_template.json**: add entries for new OpenAI and Anthropic models with max_tokens, supports_images and cost_per_1k_tokens

## Test plan

- [ ] Open `givephotobankreadymediafiles` model selector and verify new models appear in dropdowns
- [ ] Select a new Anthropic model (e.g. `claude-sonnet-4-6`) and confirm metadata generation works
- [ ] Select a new OpenAI model (e.g. `gpt-4.1-mini`) and confirm metadata generation works
- [ ] Run unit tests: `givephotobankreadymediafiles/tests/unit/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)